### PR TITLE
Fix #22 Primary Domain setting retained after adding non primary mapping

### DIFF
--- a/inc/api.php
+++ b/inc/api.php
@@ -10,7 +10,9 @@ function dark_matter_api_add_domain( $domain = '', $is_primary = false, $is_http
 		return false;
 	}
 
-	dark_matter_api_unset_domain_primary();
+	if ( $is_primary ) {
+		dark_matter_api_unset_domain_primary();
+	}
 
 	$insert = $wpdb->insert( $wpdb->dmtable, array(
 		'blog_id' => get_current_blog_id(),


### PR DESCRIPTION
Only unset the primary domain if the new domain is primary itself. This prevents the situation where no domain is primary. Fixes #22 