### PR TITLE
Bug fixes for REST API

### DIFF
--- a/inc/redirects.php
+++ b/inc/redirects.php
@@ -102,12 +102,21 @@ function dark_matter_main_redirect() {
     /** Do not redirect the Cron URL. */
     if ( defined( 'DOING_CRON' ) ) {
         return;
-    }
+	}
 
-    /** Also do not redirect for the version 1.x.x of the WP REST API. */
-    if ( defined( 'JSON_API_VERSION' ) && ( false !== strpos( $_SERVER['REQUEST_URI'], 'wp-json/' ) || ( defined( 'JSON_REQUEST' ) && JSON_REQUEST ) ) ) {
-        return;
-    }
+	/**
+	 * Do not redirect REST API calls. Why is it implemented this way rather than
+	 * some simplified method using constants? It appears that the form of REST
+	 * API that made it WordPress Core does not set a constant until after the
+	 * hook, "parse_request". Which is a lot later than this one.
+	 * 
+	 * So with that ... forced to resort to good ol' fashioned URI checking :-/
+	 * 
+	 * @link https://github.com/WordPress/WordPress/blob/4.9.4/wp-includes/default-filters.php#L402 Hook to rest_api_loaded().
+	 */
+	if ( false !== strpos( $_SERVER['REQUEST_URI'], 'wp-json/' ) ) {
+		return;
+	}
 
     /** If a request on XML-RPC, then also exit. */
     if ( defined( 'XMLRPC_REQUEST' ) ) {

--- a/inc/redirects.php
+++ b/inc/redirects.php
@@ -87,7 +87,7 @@ function dark_matter_main_redirect() {
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		return;
 	}
-	
+
     /** If Preview, then exit and let the wp action hook handle it. */
     if ( array_key_exists( 'preview', $_GET ) || array_key_exists( 'p', $_GET ) ) {
         return;
@@ -102,19 +102,21 @@ function dark_matter_main_redirect() {
     /** Do not redirect the Cron URL. */
     if ( defined( 'DOING_CRON' ) ) {
         return;
-	}
+    }
 
-	/**
+    /**
 	 * Do not redirect REST API calls. Why is it implemented this way rather than
 	 * some simplified method using constants? It appears that the form of REST
 	 * API that made it WordPress Core does not set a constant until after the
 	 * hook, "parse_request". Which is a lot later than this one.
-	 * 
+	 *
 	 * So with that ... forced to resort to good ol' fashioned URI checking :-/
-	 * 
+	 *
 	 * @link https://github.com/WordPress/WordPress/blob/4.9.4/wp-includes/default-filters.php#L402 Hook to rest_api_loaded().
 	 */
-	if ( false !== strpos( $_SERVER['REQUEST_URI'], 'wp-json/' ) ) {
+    $rest_url_prefix = trailingslashit( rest_get_url_prefix() );
+
+    if ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_url_prefix ) ) {
 		return;
 	}
 

--- a/inc/urls.php
+++ b/inc/urls.php
@@ -139,7 +139,7 @@ function dark_matter_admin_pre_option_home( $value ) {
  * depends on getting the mapped domain gets it correctly.
  */
 if ( is_admin() || ( defined( 'DOING_CRON' ) && DOING_CRON ) && property_exists( $current_blog, 'primary_domain' ) ) {
-    add_filter( 'pre_option_home', 'dark_matter_admin_pre_option_home' );
+    add_filter( 'home_url', 'dark_matter_home_url', 10, 4 );
 
     add_filter( 'comment_row_actions', 'dark_matter_post_row_actions' );
     add_filter( 'post_row_actions', 'dark_matter_post_row_actions' );
@@ -150,6 +150,14 @@ if ( is_admin() || ( defined( 'DOING_CRON' ) && DOING_CRON ) && property_exists(
     add_filter( 'get_comment_author_url', 'dark_matter_api_map_permalink' );
 
     add_filter( 'preview_post_link', 'dark_matter_api_unmap_permalink' );
+}
+
+function dark_matter_home_url( $url, $path, $scheme, $blog_id ) {
+    if ( 'rest' !== $scheme ) {
+        return dark_matter_api_map_permalink( $url );
+    }
+
+    return $url;
 }
 
 function dark_matter_allowed_redirect_hosts( $allowed_hosts ) {


### PR DESCRIPTION
Fixes two, separate, issues relating to the REST API. These are;

* No longer erroneously redirects REST API URLs using the admin domain.
  * REST API URLs on the mapped domain were unaffected.
* Changed to use "home_url" filter hook rather than "pre_option_home_url".
  * This is because "home_url" passes as a parameter the scheme, which is "rest" when called through get_rest_url(). This fixes issue #27.
  * This change / fix addresses REST API compatibility issues with plugins such as Redirection, Regenerate Thumbnails, and Yoast SEO.
  * The error in the browser console was; "Request header field x-wp-nonce is not allowed by Access-Control-Allow-Headers in preflight response."