### PR TITLE
WIP: 2.0.0 Hooks and Extensibility

### DIFF
--- a/domain-mapping/api/DarkMatter_Domains.php
+++ b/domain-mapping/api/DarkMatter_Domains.php
@@ -76,7 +76,18 @@ class DarkMatter_Domains {
             return new WP_Error( 'reserved', __( 'This domain has been reserved.', 'dark-matter' ) );
         }
 
-        return $fqdn;
+        /**
+         * Allow for additional checks beyond the in-built Dark Matter ones.
+         *
+         * Ensure that in the case of an error, it should return a WP_Error
+         * object. This is used when providing error messages to the CLI and
+         * REST API endpoints.
+         *
+         * @since 2.0.0
+         *
+         * @param string $fqdn Fully qualified domain name.
+         */
+        return apply_filters( 'darkmatter_domain_basic_check', $fqdn );
     }
 
     /**

--- a/domain-mapping/api/DarkMatter_Domains.php
+++ b/domain-mapping/api/DarkMatter_Domains.php
@@ -227,6 +227,18 @@ class DarkMatter_Domains {
             $cache_key = md5( $fqdn );
             wp_cache_delete( $cache_key, 'dark-matter' );
 
+            /**
+             * Fire action when a domain is deleted.
+             *
+             * Fires after a domain is successfully deleted to the database.
+             * This is also after the domain is deleted from cache.
+             *
+             * @since 2.0.0
+             *
+             * @param DM_Domain $_domain Domain object that was deleted.
+             */
+            do_action( 'darkmatter_domain_delete', $_domain );
+
             return true;
         }
 

--- a/domain-mapping/api/DarkMatter_Domains.php
+++ b/domain-mapping/api/DarkMatter_Domains.php
@@ -147,7 +147,21 @@ class DarkMatter_Domains {
                 $dm_primary->set( get_current_blog_id(), $fqdn );
             }
 
-            return new DM_Domain( (object) $_domain );
+            $dm_domain = new DM_Domain( (object) $_domain );
+
+            /**
+             * Fire action when a domain is added.
+             *
+             * Fires after a domain is successfully added to the database. This
+             * is also post insertion to the cache.
+             *
+             * @since 2.0.0
+             *
+             * @param DM_Domain $dm_domain Domain object of the newly added Domain.
+             */
+            do_action( 'darkmatter_domain_add', $dm_domain );
+
+            return $dm_domain;
         }
 
         return new WP_Error( 'unknown', __( 'Sorry, the domain could not be added. An unknown error occurred.', 'dark-matter' ) );

--- a/domain-mapping/api/DarkMatter_Domains.php
+++ b/domain-mapping/api/DarkMatter_Domains.php
@@ -474,6 +474,17 @@ class DarkMatter_Domains {
             }
 
             $domain_after = new DM_Domain( (object) $_domain );
+
+            /**
+             * Fires when a domain is updated.
+             *
+             * @since 2.0.0
+             *
+             * @param DM_Domain $domain_after  Domain object after the changes have been applied successfully.
+             * @param DM_Domain $domain_before Domain object before.
+             */
+            do_action( 'darkmatter_domain_updated', $domain_after, $domain_before );
+
             return $domain_after;
         }
 

--- a/domain-mapping/api/DarkMatter_Primary.php
+++ b/domain-mapping/api/DarkMatter_Primary.php
@@ -135,6 +135,17 @@ class DarkMatter_Primary {
             ) );
         }
 
+        /**
+         * Fires when a domain is set to be the primary for a Site.
+         *
+         * @since 2.0.0
+         *
+         * @param  string  $domain  Domain that is set to primary domain.
+         * @param  integer $site_id Site ID.
+         * @param  boolean $db      States if the change performed a database update.
+         */
+        do_action( 'darkmatter_primary_set', $domain, $site_id, $db );
+
         wp_cache_set( $cache_key, $domain, 'dark-matter' );
     }
 

--- a/domain-mapping/api/DarkMatter_Primary.php
+++ b/domain-mapping/api/DarkMatter_Primary.php
@@ -184,6 +184,17 @@ class DarkMatter_Primary {
             }
         }
 
+        /**
+         * Fires when a domain is unset to be the primary for a Site.
+         *
+         * @since 2.0.0
+         *
+         * @param  string  $domain  Domain that is unset to primary domain.
+         * @param  integer $site_id Site ID.
+         * @param  boolean $db      States if the change performed a database update.
+         */
+        do_action( 'darkmatter_primary_set', $domain, $site_id, $db );
+
         $cache_key = $site_id . '-primary';
         wp_cache_delete( $cache_key, 'dark-matter' );
 

--- a/domain-mapping/api/DarkMatter_Primary.php
+++ b/domain-mapping/api/DarkMatter_Primary.php
@@ -193,7 +193,7 @@ class DarkMatter_Primary {
          * @param  integer $site_id Site ID.
          * @param  boolean $db      States if the change performed a database update.
          */
-        do_action( 'darkmatter_primary_set', $domain, $site_id, $db );
+        do_action( 'darkmatter_primary_unset', $domain, $site_id, $db );
 
         $cache_key = $site_id . '-primary';
         wp_cache_delete( $cache_key, 'dark-matter' );

--- a/domain-mapping/api/DarkMatter_Restrict.php
+++ b/domain-mapping/api/DarkMatter_Restrict.php
@@ -131,6 +131,15 @@ class DarkMatter_Restrict {
 
         $this->refresh_cache();
 
+        /**
+         * Fires when a domain is deleted from the restricted list.
+         *
+         * @since 2.0.0
+         *
+         * @param string $fqdn Domain name that was restricted.
+         */
+        do_action( 'darkmatter_restrict_delete', $fqdn );
+
         return true;
     }
 

--- a/domain-mapping/api/DarkMatter_Restrict.php
+++ b/domain-mapping/api/DarkMatter_Restrict.php
@@ -154,6 +154,16 @@ class DarkMatter_Restrict {
          */
         $restrict_domains = wp_cache_get( 'restrictd', 'dark-matter' );
 
+        /**
+         * Fires after the domains have been retrieved from cache (if available)
+         * and before the database is used to retrieve the Restricted domains.
+         *
+         * @since 2.0.0
+         *
+         * @param array $restricted_domains Restricted domains retrieved from Object Cache.
+         */
+        $restrict_domains = apply_filters( 'darkmatter_restricted_get', $restrict_domains );
+
         if ( $restrict_domains ) {
             return $restrict_domains;
         }

--- a/domain-mapping/api/DarkMatter_Restrict.php
+++ b/domain-mapping/api/DarkMatter_Restrict.php
@@ -88,6 +88,15 @@ class DarkMatter_Restrict {
 
         $this->refresh_cache();
 
+        /**
+         * Fires when a domain is added to the restricted list.
+         *
+         * @since 2.0.0
+         *
+         * @param string $fqdn Domain name that was restricted.
+         */
+        do_action( 'darkmatter_restrict_add', $fqdn );
+
         return true;
     }
 


### PR DESCRIPTION
Adds the following actions to Dark Matter 2.0.0 for extensibility.

* `darkmatter_domain_add` - fires after a domain is successfully added to the database and object cache.
* `darkmatter_domain_basic_check` - fires at the end of the checks for a domain. Enables additional checks which are environment specific.
* `darkmatter_domain_delete ` - fires after a domain is successfully deleted from the database and object cace.
* `darkmatter_domain_updated ` - fires after a domain is successfully updated.
* `darkmatter_primary_set ` - Fires after a domain is set as the primary domain for a site.
* `darkmatter_primary_unset` - Fires after a domain is unset as the primary domain for a site.
* `darkmatter_restrict_add` - Fires after a domain is successfully added to the Restricted list.
* `darkmatter_restrict_get` - Fires between the Restricted domains being returned from Object Cache and then going to the database.
* `darkmatter_restrict_delete` - Fires after a domain is successfully deleted to the Restricted list.