### PR TITLE
Fix undefined variable $is_admin

### DIFF
--- a/domain-mapping/inc/redirect.php
+++ b/domain-mapping/inc/redirect.php
@@ -91,6 +91,8 @@ function darkmatter_maybe_redirect() {
 
     $host    = trim( $_SERVER['HTTP_HOST'], '/' );
     $primary = DarkMatter_Primary::instance()->get();
+    
+    $is_admin = false;
 
     if ( is_admin() || in_array( $filename, array( 'wp-login.php', 'wp-register.php' ) ) ) {
         $is_admin = true;


### PR DESCRIPTION
The variable is usdefined on line 96 resulting in a PHP notice. Thanks for the report @cmcandrew