### PR TITLE
Fix for oEmbeds using mapped domains

### DIFF
--- a/domain-mapping/classes/DM_URL.php
+++ b/domain-mapping/classes/DM_URL.php
@@ -90,6 +90,18 @@ class DM_URL {
     }
 
     /**
+     * Checks to ensure that "mapped" domains are considered internal to WordPress and not external.
+     *
+     * @param  bool   $external Whether HTTP request is external or not.
+     * @param  string $host     Host name of the requested URL.
+     * @param  string $url      Requested URL.
+     * @return bool             False if the URL is "mapped" domain. The provided $external value otherwise.
+     */
+    public function is_external( $external = false, $host = '', $url = '' ) {
+        return $external;
+    }
+
+    /**
      * Determines if the requested domain is mapped using the DOMAIN_MAPPING
      * constant from sunrise.php.
      *
@@ -143,6 +155,7 @@ class DM_URL {
      */
     public function prepare() {
         add_filter( 'the_content', array( $this, 'map' ), 50, 1 );
+        add_filter( 'http_request_host_is_external', array( $this, 'is_external' ), 10, 1 );
 
         /**
          * We only wish to affect `the_content` for Previews and nothing else.


### PR DESCRIPTION
This PR includes a fix for oEmbeds which are being included to posts using the mapped domains. 

The IP address is likely to have WordPress consider the domains "external", which ... technically ... they are, rather than "internal".

Logic has been added to the `http_request_host_is_external` ([Reference](https://developer.wordpress.org/reference/hooks/http_request_host_is_external/)) to make the domains identify as "internal" rather than "external".

## Local Testing Notes

If you are using self-signed certificates, you will need to disable WordPress' SSL verify on cURL requests. This can be done using the following code;

```php
function dm_temp_test_http_request_args( $parsed_args, $url ) {
    $parsed_args['sslverify'] = false;

    return $parsed_args;
}
add_filter( 'http_request_args', 'dm_temp_test_http_request_args', 10, 2 );
```