### PR TITLE
Browser / no cache headers for SSO flow

### DIFF
--- a/dark-matter.php
+++ b/dark-matter.php
@@ -53,7 +53,7 @@ require_once DM_PATH . '/domain-mapping/api/DarkMatter_Domains.php';
 require_once DM_PATH . '/domain-mapping/api/DarkMatter_Primary.php';
 require_once DM_PATH . '/domain-mapping/api/DarkMatter_Restrict.php';
 
-if ( ! defined( 'DM_SSO_TYPE' ) || 'disable' !== DM_SSO_TYPE ) {
+if ( ! defined( 'DARKMATTER_SSO_TYPE' ) || 'disable' !== DARKMATTER_SSO_TYPE ) {
     require_once DM_PATH . '/domain-mapping/sso/DM_SSO_Cookie.php';
 }
 

--- a/dark-matter.php
+++ b/dark-matter.php
@@ -32,7 +32,7 @@ defined( 'ABSPATH' ) || die;
 
 /** Setup the Plugin Constants */
 define( 'DM_PATH', plugin_dir_path( __FILE__ ) );
-define( 'DM_VERSION', '2.0.2' );
+define( 'DM_VERSION', '2.0.3' );
 define( 'DM_DB_VERSION', '20190114' );
 
 define( 'DM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/dark-matter.php
+++ b/dark-matter.php
@@ -53,7 +53,9 @@ require_once DM_PATH . '/domain-mapping/api/DarkMatter_Domains.php';
 require_once DM_PATH . '/domain-mapping/api/DarkMatter_Primary.php';
 require_once DM_PATH . '/domain-mapping/api/DarkMatter_Restrict.php';
 
-require_once DM_PATH . '/domain-mapping/sso/DM_SSO_Cookie.php';
+if ( ! defined( 'DM_SSO_TYPE' ) || 'disable' !== DM_SSO_TYPE ) {
+    require_once DM_PATH . '/domain-mapping/sso/DM_SSO_Cookie.php';
+}
 
 require_once DM_PATH . '/domain-mapping/rest/DM_REST_Domains_Controller.php';
 require_once DM_PATH . '/domain-mapping/rest/DM_REST_Restricted_Controller.php';

--- a/domain-mapping/inc/redirect.php
+++ b/domain-mapping/inc/redirect.php
@@ -91,7 +91,7 @@ function darkmatter_maybe_redirect() {
 
     $host    = trim( $_SERVER['HTTP_HOST'], '/' );
     $primary = DarkMatter_Primary::instance()->get();
-    
+
     $is_admin = false;
 
     if ( is_admin() || in_array( $filename, array( 'wp-login.php', 'wp-register.php' ) ) ) {
@@ -147,7 +147,9 @@ function darkmatter_maybe_redirect() {
         return;
     }
 
+    header( 'X-Redirect-By: Dark-Matter' );
     header( 'Location:' . $url, true, 301 );
+
     die;
 }
 

--- a/domain-mapping/sso/DM_SSO_Cookie.php
+++ b/domain-mapping/sso/DM_SSO_Cookie.php
@@ -136,6 +136,22 @@ class DM_SSO_Cookie {
     }
 
     /**
+     * Sets the relevant no cache headers using the definition from WordPress Core.
+     *
+     * @return void
+     */
+    public function nocache_headers() {
+        /**
+         * Set the headers to prevent caching of the JavaScript include.
+         */
+        $nocache_headers = wp_get_nocache_headers();
+
+        foreach ( $nocache_headers as $header_name => $header_value ) {
+            header( "{$header_name}: {$header_value}" );
+        }
+    }
+
+    /**
      * Handle the validation of the login token and logging in of a user. Also
      * handle the logout if that action is provided.
      *

--- a/domain-mapping/sso/DM_SSO_Cookie.php
+++ b/domain-mapping/sso/DM_SSO_Cookie.php
@@ -145,6 +145,10 @@ class DM_SSO_Cookie {
      * @return void
      */
     public function nocache_headers() {
+        if ( headers_sent() ) {
+            return;
+        }
+
         /**
          * Set the headers to prevent caching of the JavaScript include.
          */

--- a/domain-mapping/sso/DM_SSO_Cookie.php
+++ b/domain-mapping/sso/DM_SSO_Cookie.php
@@ -165,6 +165,13 @@ class DM_SSO_Cookie {
         $dm_action = filter_input( INPUT_GET, '__dm_action' );
 
         /**
+         * Ensure that URLs with the __dm_action query string are not cached by browsers.
+         */
+        if ( ! empty( $dm_action ) ) {
+            $this->nocache_headers();
+        }
+
+        /**
          * First check to see if the authorise action is provided in the URL.
          */
         if ( 'authorise' === $dm_action ) {

--- a/domain-mapping/sso/DM_SSO_Cookie.php
+++ b/domain-mapping/sso/DM_SSO_Cookie.php
@@ -162,10 +162,12 @@ class DM_SSO_Cookie {
      * @return void
      */
     public function validate_token() {
+        $dm_action = filter_input( INPUT_GET, '__dm_action' );
+
         /**
          * First check to see if the authorise action is provided in the URL.
          */
-        if ( 'authorise' === filter_input( INPUT_GET, '__dm_action' ) ) {
+        if ( 'authorise' === $dm_action ) {
             /**
              * Validate the token provided in the URL.
              */
@@ -189,7 +191,7 @@ class DM_SSO_Cookie {
                 die();
             }
         }
-        else if ( 'logout' === filter_input( INPUT_GET, '__dm_action' ) ) {
+        else if ( 'logout' === $dm_action ) {
             wp_logout();
             wp_redirect( esc_url( remove_query_arg( array( '__dm_action' ) ) ), 302, 'Dark-Matter' );
 

--- a/domain-mapping/sso/DM_SSO_Cookie.php
+++ b/domain-mapping/sso/DM_SSO_Cookie.php
@@ -165,13 +165,13 @@ class DM_SSO_Cookie {
                  * removed.
                  */
                 wp_set_auth_cookie( $user_id );
-                wp_redirect( esc_url( remove_query_arg( array( '__dm_action', 'auth' ) ) ) );
+                wp_redirect( esc_url( remove_query_arg( array( '__dm_action', 'auth' ) ) ), 302, 'Dark-Matter' );
                 die();
             }
         }
         else if ( 'logout' === filter_input( INPUT_GET, '__dm_action' ) ) {
             wp_logout();
-            wp_redirect( esc_url( remove_query_arg( array( '__dm_action' ) ) ) );
+            wp_redirect( esc_url( remove_query_arg( array( '__dm_action' ) ) ), 302, 'Dark-Matter' );
 
             die();
         }

--- a/domain-mapping/sso/DM_SSO_Cookie.php
+++ b/domain-mapping/sso/DM_SSO_Cookie.php
@@ -41,6 +41,8 @@ class DM_SSO_Cookie {
     public function login_token() {
         header( 'Content-Type: text/javascript' );
 
+        $this->nocache_headers();
+
         /**
          * Ensure that the JavaScript is never empty.
          */
@@ -71,6 +73,8 @@ class DM_SSO_Cookie {
      */
     public function logout_token() {
         header( 'Content-Type: text/javascript' );
+
+        $this->nocache_headers();
 
         /**
          * Ensure that the JavaScript is never empty.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dark-matter",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Domain Mapping plugin for WordPress.",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: domain mapping, multisite
 Requires at least: 5.0
 Requires PHP: 7.0.0
 Tested up to: 5.3
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,8 @@ Google Analytics) with over 60 websites.
 * Added and ensured that the no cache headers are used on all requests for the SSO flow.
   * This should aid with installations that utilise more pronounced caching setups.
 * Modified the redirects to ensure that X-Redirect-By header is identified as "Dark Matter" rather than "WordPress".
+* Added support for a new constant, DARKMATTER_SSO_TYPE, which can be set to a value of "disable" to stop SSO functionality.
+  * In future, this will support a few SSO implementations depending on preference.
 
 = 2.0.2 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,12 @@ Google Analytics) with over 60 websites.
 
 == Changelog ==
 
+= 2.0.3 =
+
+* Added and ensured that the no cache headers are used on all requests for the SSO flow.
+  * This should aid with installations that utilise more pronounced caching setups.
+* Modified the redirects to ensure that X-Redirect-By header is identified as "Dark Matter" rather than "WordPress".
+
 = 2.0.2 =
 
 * Added logic to ensure that mapped domains are not considered "external" which was preventing oEmbeds from working.


### PR DESCRIPTION
A recent setup which uses an AWS CloudFront in front of WordPress has noticed that the cache headers - `Cache-Control` / `Expires` - is not always present on some requests / URLs related to the SSO flow.

This PR ensures that the headers are present and adheres to how WordPress issues the headers, by utilising the `wp_get_nocache_headers()` ([Doc Ref](https://developer.wordpress.org/reference/functions/wp_get_nocache_headers/)) function. It doesn't use the `nocache_headers()` function in case we need to add additional headers specifically for Dark Matter support in the future.

In addition, the redirects have been updated to ensure that the `X-Redirect-By` header value is for Dark Matter and not WordPress.