### PR TITLE
Yoast SEO / Math Rank SEO compatibility updates

### DIFF
--- a/dark-matter.php
+++ b/dark-matter.php
@@ -48,6 +48,11 @@ require_once DM_PATH . '/domain-mapping/classes/class-dm-domain.php';
 require_once DM_PATH . '/domain-mapping/classes/class-dm-healthchecks.php';
 require_once DM_PATH . '/domain-mapping/classes/class-dm-url.php';
 
+/**
+ * Plugin compatibility.
+ */
+require_once DM_PATH . '/domain-mapping/classes/third-party/class-dm-yoast.php';
+
 if ( ! defined( 'DARKMATTER_HIDE_UI' ) || ! DARKMATTER_HIDE_UI ) {
 	require_once DM_PATH . '/domain-mapping/classes/class-dm-ui.php';
 }

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -274,32 +274,6 @@ class DM_URL {
 		add_filter( 'home_url', array( $this, 'siteurl' ), -10, 4 );
 
 		/**
-		 * Ignore the custom column to prevent accidental domain mappings. Specifically Yoast since version 14 and the
-		 * introduction of Indexables.
-		 *
-		 * @link https://yoast.com/indexables/
-		 */
-		$post_types = get_post_types( null, 'names' );
-
-		foreach ( $post_types as $post_type ) {
-			add_action(
-				'manage_' . $post_type . '_posts_custom_column',
-				function () {
-					remove_filter( 'home_url', array( $this, 'siteurl' ), -10, 4 );
-				},
-				1
-			);
-
-			add_action(
-				'manage_' . $post_type . '_posts_custom_column',
-				function () {
-					add_filter( 'home_url', array( $this, 'siteurl' ), -10, 4 );
-				},
-				PHP_INT_MAX
-			);
-		}
-
-		/**
 		 * The Preview link in the metabox of Post Publish cannot be handled by the home_url hook. This is because it
 		 * uses get_permalink() to retrieve the URL before appending the "preview=true" query string parameter.
 		 *

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -140,6 +140,25 @@ class DM_URL {
 	}
 
 	/**
+	 * Unmap URLs prior to the post being created / updated in the database. This ensures that unmapped domains are
+	 * stored in the database if provided as well as fixing some issues related internal link tracking used by SEO
+	 * plugins.
+	 *
+	 * This can occur due to the "Search" REST endpoint returning mapped domains (as per Gutenberg) and / or admins and
+	 * editors copying and pasting links by navigating the public-facing side of the website.
+	 *
+	 * @param array $data An array of slashed, sanitized, and processed post data.
+	 * @return array Post data, with URLs unmapped.
+	 */
+	public function insert_post( $data = [] ) {
+		if ( ! empty( $data['post_content'] ) ) {
+			$data['post_content'] = $this->unmap( $data['post_content'] );
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Determines if the requested domain is mapped using the DOMAIN_MAPPING
 	 * constant from sunrise.php.
 	 *
@@ -200,6 +219,7 @@ class DM_URL {
 	public function prepare() {
 		add_filter( 'the_content', array( $this, 'map' ), 50, 1 );
 		add_filter( 'http_request_host_is_external', array( $this, 'is_external' ), 10, 2 );
+		add_filter( 'wp_insert_post_data', array( $this, 'insert_post' ), -10, 1 );
 
 		/**
 		 * We only wish to affect `the_content` for Previews and nothing else.

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -219,7 +219,7 @@ class DM_URL {
 		$request_uri = ( empty( $_SERVER['REQUEST_URI'] ) ? '' : filter_var( $_SERVER['REQUEST_URI'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) );
 
 		if ( is_admin() ) {
-			add_action( 'admin_init', array( $this, 'prepare_admin' ) );
+			add_action( 'init', array( $this, 'prepare_admin' ) );
 			return;
 		}
 

--- a/domain-mapping/classes/third-party/class-dm-yoast.php
+++ b/domain-mapping/classes/third-party/class-dm-yoast.php
@@ -13,6 +13,10 @@ class DM_Yoast {
 	 * DM_Yoast constructor.
 	 */
 	public function __construct() {
+		if ( defined( 'WPSEO_VERSION' ) ) {
+			return;
+		}
+
 		add_filter( 'wpseo_should_save_indexable', [ $this, 'fix_indexable_permalinks' ], 10, 2 );
 	}
 
@@ -42,6 +46,4 @@ class DM_Yoast {
 /**
  * Only instantiate this class if Yoast SEO is in use.
  */
-if ( defined( 'WPSEO_VERSION' ) ) {
-	new DM_Yoast();
-}
+new DM_Yoast();

--- a/domain-mapping/classes/third-party/class-dm-yoast.php
+++ b/domain-mapping/classes/third-party/class-dm-yoast.php
@@ -38,4 +38,10 @@ class DM_Yoast {
 		return $intend_to_save;
 	}
 }
-new DM_Yoast();
+
+/**
+ * Only instantiate this class if Yoast SEO is in use.
+ */
+if ( defined( 'WPSEO_VERSION' ) ) {
+	new DM_Yoast();
+}

--- a/domain-mapping/classes/third-party/class-dm-yoast.php
+++ b/domain-mapping/classes/third-party/class-dm-yoast.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Compatibility adjustments for supporting Yoast SEO.
+ */
+
+/**
+ * Class DM_Yoast
+ *
+ * @since 2.1.3
+ */
+class DM_Yoast {
+	/**
+	 * DM_Yoast constructor.
+	 */
+	public function __construct() {
+		add_filter( 'wpseo_should_save_indexable', [ $this, 'fix_indexable_permalinks' ], 10, 2 );
+	}
+
+	/**
+	 * Correct indexables permalinks to be unmapped prior to save to the database. This works with versions 15.1+ of
+	 * Yoast SEO. Version 15.1 - which contains the `wpseo_should_save_indexable` was released on 14th October 2020.
+	 *
+	 * @link https://github.com/Yoast/wordpress-seo/blob/15.1/src/builders/indexable-builder.php#L296
+	 *
+	 * @param boolean $intend_to_save Whether the indexable is to be saved or not.
+	 * @param \Yoast\WP\SEO\Models\Indexable $indexable The indexable to be saved.
+	 * @return boolean The default value of "intend to save".
+	 */
+	public function fix_indexable_permalinks( $intend_to_save, $indexable ) {
+		/**
+		 * If saving to the database, then make sure the permalink is unmapped.
+		 */
+		if ( $intend_to_save ) {
+			$dm_url = DM_URL::instance();
+			$indexable->permalink = $dm_url->unmap( $indexable->permalink );
+		}
+
+		return $intend_to_save;
+	}
+}
+new DM_Yoast();


### PR DESCRIPTION
The following changes have been added for SEO plugin compatibility:

* **All**:
  * Prior to updating the database for create / updates to post, the `post_content` is passed through the "unmap" to remove mapped domains. (This only applies to URLs which make use of the "primary domain" and will not impact all URLs.)
  * This resolves issues in Rank Math SEO and Yoast SEO in detecting and counting "internal links".
  * This compensates - although _does not solve_ - an issue where Gutenberg's inline link tool can introduce mapped domains through it's use of the Search REST endpoint.
* **Yoast SEO**:
  * Introduced a new class for Yoast SEO specific fixes.
  * Made use of a new-ish filter from Yoast SEO, `wpseo_should_save_indexable`, which was added in version 15.1 (although omitted from the release notes ...) released in October. This will now ensure all "Indexables" are unmapped without some esoteric fixes going forward.
  * As such, removed the previous esoteric fix added to the `manage_{post_type}_posts_custom_column` to prevent mapped domains getting into the indexables.
* **Rank Math SEO**:
  * Rudimentary testing for compatibility conducted for the first time.