### PR TITLE
Small URL mapping and redirect performance enhancements

### DIFF
--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -342,18 +342,21 @@ class DM_URL {
 			return $url;
 		}
 
-		$valid_schemes = array( 'http', 'https' );
+		$valid_schemes = array(
+			'http'  => true,
+			'https' => true,
+		);
 
 		if ( ! is_admin() ) {
-			$valid_schemes[] = 'json';
-			$valid_schemes[] = 'rest';
+			$valid_schemes['json'] = true;
+			$valid_schemes['rest'] = true;
 		}
 
 		if ( apply_filters( 'darkmatter_allow_logins', false ) ) {
 			$valid_schemes[] = 'login';
 		}
 
-		if ( null === $scheme || in_array( $scheme, $valid_schemes ) ) {
+		if ( null === $scheme || array_key_exists( $scheme, $valid_schemes ) ) {
 			/**
 			 * Ensure that if the REST API is called on the admin domain that we do not map the `_links` property on
 			 * the response. This will ensure that any integration using these sticks to the correct domain.

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -96,11 +96,11 @@ class DM_URL {
 		}
 
 		$valid_paths = array(
-			'admin-ajax.php',
-			'admin-post.php',
+			'admin-ajax.php' => true,
+			'admin-post.php' => true,
 		);
 
-		if ( in_array( $filename, $valid_paths ) ) {
+		if ( array_key_exists( $filename, $valid_paths ) ) {
 			return $this->map( $url, $blog_id );
 		}
 

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -281,12 +281,17 @@ class DM_URL {
 		 * old AJAX. Therefore we check the referer to ensure it's the admin
 		 * side rather than the front-end.
 		 */
+		$valid_actions = [
+			'query-attachments' => true,
+			'sample-permalink'  => true,
+			'upload-attachment' => true,
+		];
 
 		if ( wp_doing_ajax()
 			&&
 				false !== stripos( wp_get_referer(), '/wp-admin/' )
 			&&
-				( empty( $_POST['action'] ) || ! in_array( $_POST['action'], array( 'query-attachments', 'sample-permalink', 'upload-attachment' ) ) ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+				( empty( $_POST['action'] ) || ! array_key_exists( $_POST['action'], $valid_actions ) ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		) {
 			return;
 		}

--- a/domain-mapping/inc/redirect.php
+++ b/domain-mapping/inc/redirect.php
@@ -89,11 +89,16 @@ function darkmatter_maybe_redirect() {
 	$filename = basename( $request );
 	$filename = strtok( $filename, '?' );
 
+	$ajax_filenames = array(
+		'admin-post.php' => true,
+		'admin-ajax.php' => true,
+	);
+
 	/**
 	 * Check to see if the current request is an Admin Post action or an AJAX action. These two requests in Dark Matter
 	 * can be on either the admin domain or the primary domain.
 	 */
-	if ( in_array( $filename, array( 'admin-post.php', 'admin-ajax.php' ), true ) ) {
+	if ( array_key_exists( $filename, $ajax_filenames ) ) {
 		return;
 	}
 
@@ -106,7 +111,12 @@ function darkmatter_maybe_redirect() {
 
 	$is_admin = false;
 
-	if ( is_admin() || in_array( $filename, array( 'wp-login.php', 'wp-register.php' ) ) ) {
+	$admin_filenames = array(
+		'wp-login.php'    => true,
+		'wp-register.php' => true,
+	);
+
+	if ( is_admin() || array_key_exists( $filename, $admin_filenames ) ) {
 		$is_admin = true;
 	}
 


### PR DESCRIPTION
This PR strategically replaces the use of `in_array()` in favour of `array_key_exists()` to improve performance, as noted by this benchmark run here: https://3v4l.org/K046Q/perf#output. This benchmark also illustrates that this improvement holds for PHP 8.0 as well as the various PHP 7.x releases.

Changes are primarily focused on areas where `in_array()` is used often, such as URL mapping and redirection, with a specific focus on improving load times and performance of the public-facing side running the primary domain.

Release notes:

* Tweaked some conditional checks to code which is more performant. The logic is identical to before, just utilising a slightly different mechanism to achieve it. This change was applied to:
  * Detecting and executing redirects, such as those from secondary domains to the primary domain as well as login and admin pages to the admin domain.
  * A check for mapping `admin-ajax.php` and `admin-post.php` appropriately on the primary domain.
  * URL mapping on the admin side.
  * URL mapping for Home URL and Site URL options.