### PR TITLE
Fix for oEmbeds on mapped domains

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "cameronterry/dark-matter",
-    "version": "2.1.4",
+    "version": "2.1.5",
     "description": "A highly opinionated domain mapping plugin for WordPress.",
     "type": "wordpress-plugin",
     "license": "GPL-2.0+",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b411769cd02014874103967cf2e9a64b",
+    "content-hash": "1593ccda7b23a783d04489361eb92d93",
     "packages": [],
     "packages-dev": [
         {

--- a/dark-matter.php
+++ b/dark-matter.php
@@ -3,7 +3,7 @@
  * Plugin Name: Dark Matter
  * Plugin URI: https://github.com/cameronterry/dark-matter
  * Description: A highly opinionated domain mapping plugin for WordPress.
- * Version: 2.1.4
+ * Version: 2.1.5
  * Author: Cameron Terry
  * Author URI: https://github.com/cameronterry/
  * Text Domain: dark-matter
@@ -34,7 +34,7 @@ defined( 'ABSPATH' ) || die;
 
 /** Setup the Plugin Constants */
 define( 'DM_PATH', plugin_dir_path( __FILE__ ) );
-define( 'DM_VERSION', '2.1.4' );
+define( 'DM_VERSION', '2.1.5' );
 define( 'DM_DB_VERSION', '20190114' );
 
 define( 'DM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -217,7 +217,27 @@ class DM_URL {
 	 * @return void
 	 */
 	public function prepare() {
-		add_filter( 'the_content', array( $this, 'map' ), 7, 1 );
+		/**
+		 * We attach twice to `the_content` filter.
+		 *
+		 * The first one with a high priority (5) is to ensure that URL processing logic - i.e. oEmbeds for other WP
+		 * posts - is working with the mapped domain. This is needed to ensure calls to `url_to_postid()` work as
+		 * intended as they compared URL hosts.
+		 *
+		 * The second one, with a low priority (50), is a fail-safe / sweep up. Other logic such as Block Editor process
+		 * on a later priority (9 at the time of writing this) to ensure it is correct prior to other plugins possibly
+		 * manipulating `post_content`, usually on the "normal" priority (10). For domain mapping, we want to ensure we
+		 * catch every thing after WordPress core and any plugins, so we run later in the process to achieve that.
+		 */
+		add_filter( 'the_content', array( $this, 'map' ), 5, 1 );
+
+		/**
+		 * Please note: the `$this->map()` method will check for unmapped URLs before committing to an regex replace. So
+		 * most of the time, this will go "nothing to do here". And the rest of time, catch any edge cases that produce
+		 * unmapped URLs.
+		 */
+		add_filter( 'the_content', array( $this, 'map' ), 50, 1 );
+
 		add_filter( 'http_request_host_is_external', array( $this, 'is_external' ), 10, 2 );
 		add_filter( 'wp_insert_post_data', array( $this, 'insert_post' ), -10, 1 );
 

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -217,7 +217,7 @@ class DM_URL {
 	 * @return void
 	 */
 	public function prepare() {
-		add_filter( 'the_content', array( $this, 'map' ), 50, 1 );
+		add_filter( 'the_content', array( $this, 'map' ), 7, 1 );
 		add_filter( 'http_request_host_is_external', array( $this, 'is_external' ), 10, 2 );
 		add_filter( 'wp_insert_post_data', array( $this, 'insert_post' ), -10, 1 );
 

--- a/domain-mapping/inc/redirect.php
+++ b/domain-mapping/inc/redirect.php
@@ -98,7 +98,7 @@ function darkmatter_maybe_redirect() {
 	 * Check to see if the current request is an Admin Post action or an AJAX action. These two requests in Dark Matter
 	 * can be on either the admin domain or the primary domain.
 	 */
-	if ( array_key_exists( $filename, $ajax_filenames ) ) {
+	if ( ! empty( $filename ) && array_key_exists( $filename, $ajax_filenames ) ) {
 		return;
 	}
 
@@ -116,7 +116,7 @@ function darkmatter_maybe_redirect() {
 		'wp-register.php' => true,
 	);
 
-	if ( is_admin() || array_key_exists( $filename, $admin_filenames ) ) {
+	if ( is_admin() || ( ! empty( $filename ) && array_key_exists( $filename, $admin_filenames ) ) ) {
 		$is_admin = true;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dark-matter",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dark-matter",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Domain Mapping plugin for WordPress.",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -79,6 +79,14 @@ Google Analytics) with over 60 websites.
 
 == Changelog ==
 
+= 2.1.5 =
+
+* Fixed a PHP notice for certain requests in the redirect logic.
+* Fixed an issue with embedding a post from the same site would not work in some circumstances.
+  * Essentially the "mapping" process would run too late and WordPress would attempt to embed by the admin domain rather than the primary mapped domain (the domain used to visit the site).
+  * The "mapping" process now runs twice; once before the oEmbed processes the post content. And again much later to ensure any dynamic blocks or other plugins have their output mapped to the primary domain.
+  * Note: when using domain mapping, it is normal to see a single embed appear twice in post meta with Dark Matter. One embed for the admin domain / editors and another for the primary domain / visitors.
+
 = 2.1.4 =
 
 * Tweaked some conditional checks to code which is more performant. The logic is identical to before, just utilising a slightly different mechanism to achieve it. This change was applied to:

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: domain mapping, multisite
 Requires at least: 5.0
 Requires PHP: 7.0.0
 Tested up to: 5.7.1
-Stable tag: 2.1.4
+Stable tag: 2.1.5
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
This PR fixes an issue where oEmbeds are some times not handled properly because the URL is jumping between the admin domain and the primary domain.

The issue is caused by the lateness of hook onto `the_content` filter, previously set to `50`. However, the auto-embed attempts to process the URL on `the_content` / priority of `8` ([Code Reference](https://github.com/WordPress/WordPress/blob/270f2011f8ec7265c3f4ddce39c77ef5b496ed1c/wp-includes/class-wp-embed.php#L39)). In turn, this caused issues with the oEmbed as it would attempt to work with an unmapped domain rather than a mapped one.