### PR TITLE
Switch editors to load with mapped URLs

### DIFF
--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -340,6 +340,24 @@ class DM_URL {
 		 * @link https://github.com/WordPress/WordPress/blob/5.2.2/wp-includes/link-template.php#L1311-L1312 Query string parameter "preview=true" being added to the URL.
 		 */
 		add_filter( 'preview_post_link', array( $this, 'unmap' ), 10, 1 );
+
+		/**
+		 * To prepare the Classic Editor, we need to attach to a very late hook to ensure that `get_current_screen()` is
+		 * available and returns something useful.
+		 */
+		add_action( 'edit_form_top', array( $this, 'prepare_classic_editor' ) );
+	}
+
+	/**
+	 * Ensures that the Classic Editor is prepared appropriately and the unmapped URLs are mapped prior to loading. This
+	 * is needed for compatibility with some SEO plugins such as Yoast.
+	 */
+	public function prepare_classic_editor() {
+		$screen = get_current_screen();
+
+		if ( is_a( $screen, 'WP_Screen' ) && 'post' === $screen->base && 'edit' === $screen->parent_base ) {
+			add_filter( 'the_editor_content', array( $this, 'map' ), 10, 1 );
+		}
 	}
 
 	/**

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -341,6 +341,30 @@ class DM_URL {
 		add_filter( 'home_url', array( $this, 'siteurl' ), -10, 4 );
 
 		add_filter( 'preview_post_link', array( $this, 'unmap' ), 10, 1 );
+
+		/**
+		 * Loop all post types with REST endpoints to fix the mapping for content.raw property.
+		 */
+		$rest_post_types = get_post_types( [ 'show_in_rest' => true ] );
+
+		foreach ( $rest_post_types as $post_type ) {
+			add_filter( "rest_prepare_{$post_type}", array( $this, 'prepare_rest_post_item' ), 10, 1 );
+		}
+	}
+
+	/**
+	 * Ensures the "raw" version of the content, typically used by Gutenberg through it's middleware pre-load / JS
+	 * hydrate process, gets handled the same as content (which runs through the `the_content` hook).
+	 *
+	 * @param  WP_REST_Response $item Individual post / item in the response that is being processed.
+	 * @return WP_REST_Response       Post / item with the content.raw, if present, mapped.
+	 */
+	public function prepare_rest_post_item( $item = null ) {
+		if ( isset( $item->data['content']['raw'] ) ) {
+			$item->data['content']['raw'] = $this->map( $item->data['content']['raw'] );
+		}
+
+		return $item;
 	}
 
 	/**

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -310,30 +310,6 @@ class DM_URL {
 	 * @return void
 	 */
 	public function prepare_admin() {
-		/**
-		 * This is to prevent the Classic Editor's AJAX action for inserting a
-		 * link from putting the mapped domain in to the database. However, we
-		 * cannot rely on `is_admin()` as this is always true for calls to the
-		 * old AJAX. Therefore we check the referer to ensure it's the admin
-		 * side rather than the front-end.
-		 */
-		$valid_actions = [
-			'query-attachments' => true,
-			'sample-permalink'  => true,
-			'upload-attachment' => true,
-		];
-
-		$action = filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING );
-
-		if ( wp_doing_ajax()
-			&&
-				false !== stripos( wp_get_referer(), '/wp-admin/' )
-			&&
-				( empty( $action ) || ! array_key_exists( $action, $valid_actions ) ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		) {
-			return;
-		}
-
 		add_filter( 'home_url', array( $this, 'siteurl' ), -10, 4 );
 
 		/**

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -21,6 +21,13 @@ class DM_URL {
 	 */
 	public function __construct() {
 		/**
+		 * In some circumstances, we always want to process the logic regardless of request type, circumstances,
+		 * conditions, etc. (like ensuring saved post data is unmapped properly).
+		 */
+		add_filter( 'http_request_host_is_external', array( $this, 'is_external' ), 10, 2 );
+		add_filter( 'wp_insert_post_data', array( $this, 'insert_post' ), -10, 1 );
+
+		/**
 		 * Prevent accidental URL mapping on requests which are not GET requests for the admin area. For example; a POST
 		 * request will include the postback for saving a post.
 		 *
@@ -237,9 +244,6 @@ class DM_URL {
 		 * unmapped URLs.
 		 */
 		add_filter( 'the_content', array( $this, 'map' ), 50, 1 );
-
-		add_filter( 'http_request_host_is_external', array( $this, 'is_external' ), 10, 2 );
-		add_filter( 'wp_insert_post_data', array( $this, 'insert_post' ), -10, 1 );
 
 		/**
 		 * We only wish to affect `the_content` for Previews and nothing else.


### PR DESCRIPTION
A recent issue highlighted in https://github.com/cameronterry/dark-matter/issues/71 details an issue with third party plugins, especially SEO focused ones such as Yoast SEO, with mapped domains.

Essentially the JavaScript and processing logic of these plugins is getting a mapped URL and then unable to identify the admin URL as the same site. This causes a discrepancy when these SEO plugins analyses the `post_content` for inbound and outbound URLs to determine an SEO score (ranked good to bad).

This PR switches Dark Matter's approach to loading the editor in a fashion similar to how the post loads on the visitor-side of a site. It also removes logic which stopped the Classic Editor link input from mapping URLs.

Furthermore, in the discovery process of this issue, a couple of other problems were corrected as well:

* Internal REST API requests, done through `rest_do_request()` ([documentation](https://developer.wordpress.org/reference/functions/rest_do_request/)), worked inconsistently due to Dark Matter only applying mapping logic if the current PHP request was for the REST API. This has been corrected and both external / internal requests will function identically.
* A previous fix to ensure `post_content` goes through the "unmapping" process was stopped for non-GET requests. This has been resolved to ensure it works for both Block Editor and Classic Editor.
* Ensured that `wp_http_validate_url()` correctly identifies external URLs - both admin and mapped / primary domains - always, regardless of request type and other conditional checks.