### PR TITLE
Fix discrepancy caused by WordPress eslint and editorconfig differences

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 2
-indent_style = space
+indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/domain-mapping/ui/API/Enums.js
+++ b/domain-mapping/ui/API/Enums.js
@@ -5,5 +5,5 @@
  */
 export const DOMAIN_TYPES = {
 	MAIN: 1,
-	MEDIA: 2
-}
+	MEDIA: 2,
+};

--- a/domain-mapping/ui/Components/DomainRow.js
+++ b/domain-mapping/ui/Components/DomainRow.js
@@ -4,7 +4,7 @@ import React from 'react';
 import DomainDisplayMedia from './DomainDisplayMedia';
 import DomainDisplayPrimary from './DomainDisplayPrimary';
 import DomainDisplaySecondary from './DomainDisplaySecondary';
-import { DOMAIN_TYPES } from "../API/Enums";
+import { DOMAIN_TYPES } from '../API/Enums';
 
 class DomainRow extends React.Component {
 	/**
@@ -21,26 +21,26 @@ class DomainRow extends React.Component {
 		this.props.update( data );
 	};
 
-  /**
-   * Handle converting domains between secondary to media domains and vice versa.
-   *
-   * @param {Object} event
-   */
-  handleConvert = ( event ) => {
-	event.preventDefault();
+	/**
+	 * Handle converting domains between secondary to media domains and vice versa.
+	 *
+	 * @param {Object} event
+	 */
+	handleConvert = ( event ) => {
+		event.preventDefault();
 
-	const data = { ...this.props.domain };
+		const data = { ...this.props.domain };
 
-	if ( DOMAIN_TYPES.MAIN === data.type ) {
-		/** Convert media domain to secondary domain. */
-		data.type = 2;
-	} else if ( DOMAIN_TYPES.MEDIA === data.type ) {
-		/** Convert media domain to secondary domain. */
-		data.type = 1;
+		if ( DOMAIN_TYPES.MAIN === data.type ) {
+			/** Convert media domain to secondary domain. */
+			data.type = 2;
+		} else if ( DOMAIN_TYPES.MEDIA === data.type ) {
+			/** Convert media domain to secondary domain. */
+			data.type = 1;
+		}
+
+		this.props.update( data );
 	}
-
-	this.props.update( data );
-  }
 
 	/**
 	 * Handle the Deleting of the domain.


### PR DESCRIPTION
TLDR: One said use 2 spaces, the other said use tabs. This caused the build to fail and this was missed as part of the deploy for 2.2.0, meaning the UI is currently broken.

Will probably need to do a wider clean-up of the JavaScript side of things, however this change will fix the immediate problem.

This should resolve: https://github.com/cameronterry/dark-matter/issues/80.