### PR TITLE
Fix cache / DB sync issue with primary domains

### DIFF
--- a/domain-mapping/api/class-darkmatter-domains.php
+++ b/domain-mapping/api/class-darkmatter-domains.php
@@ -664,9 +664,9 @@ class DarkMatter_Domains {
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param  string  $domain  Domain that is set to primary domain.
-		 * @param  integer $site_id Site ID.
-		 * @param  boolean $db      States if the change performed a database update.
+		 * @param  string  $domain     Domain that is unset to primary domain.
+		 * @param  integer $site_id    Site ID.
+		 * @param  boolean $deprecated Redundant, is always true as database is now always updated.
 		 */
 		do_action( 'darkmatter_primary_set', $domain, $blog_id, true );
 
@@ -691,9 +691,9 @@ class DarkMatter_Domains {
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param  string  $domain  Domain that is unset to primary domain.
-		 * @param  integer $site_id Site ID.
-		 * @param  boolean $db      States if the change performed a database update.
+		 * @param  string  $domain     Domain that is unset to primary domain.
+		 * @param  integer $site_id    Site ID.
+		 * @param  boolean $deprecated Redundant, is always true as database is now always updated.
 		 */
 		do_action( 'darkmatter_primary_unset', $domain, $blog_id, true );
 	}

--- a/domain-mapping/api/class-darkmatter-domains.php
+++ b/domain-mapping/api/class-darkmatter-domains.php
@@ -443,6 +443,13 @@ class DarkMatter_Domains {
 			wp_cache_add( $cache_key, $_domain, 'dark-matter' );
 
 			/**
+			 * Update the primary cache if applicable.
+			 */
+			if ( $_domain->is_primary ) {
+				wp_cache_set( $_domain->blog_id . '-primary', 'dark-matter' );
+			}
+
+			/**
 			 * We update the last changed here as the cache was modified.
 			 */
 			$this->update_last_changed();

--- a/domain-mapping/api/class-darkmatter-domains.php
+++ b/domain-mapping/api/class-darkmatter-domains.php
@@ -496,7 +496,7 @@ class DarkMatter_Domains {
 							'is_https'   => true,
 							'is_primary' => false,
 							'type'       => DM_DOMAIN_TYPE_MEDIA,
-						] 
+						]
 					);
 				}
 
@@ -754,9 +754,37 @@ class DarkMatter_Domains {
 					$this->update( $current_primary->domain, false, null, true, $current_primary->active );
 				}
 
-				$dm_primary->set( $domain_before->blog_id, $domain_before->domain );
+				/**
+				 * Update the primary domain cache.
+				 */
+				$primary_cache_key = $domain_before->blog_id . '-primary';
+
+				/**
+				 * Fires when a domain is set to be the primary for a Site.
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param  string  $domain  Domain that is set to primary domain.
+				 * @param  integer $site_id Site ID.
+				 * @param  boolean $db      States if the change performed a database update.
+				 */
+				do_action( 'darkmatter_primary_set', $domain_before->domain, $domain_before->blog_id, true );
+
+				wp_cache_set( $primary_cache_key, $domain_before->domain, 'dark-matter' );
 			} elseif ( false === $is_primary && $domain_before->is_primary ) {
-				$dm_primary->unset( $domain_before->blog_id, $domain_before->domain );
+				$primary_cache_key = $domain_before->blog_id . '-primary';
+				wp_cache_delete( $primary_cache_key, 'dark-matter' );
+
+				/**
+				 * Fires when a domain is unset to be the primary for a Site.
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param  string  $domain  Domain that is unset to primary domain.
+				 * @param  integer $site_id Site ID.
+				 * @param  boolean $db      States if the change performed a database update.
+				 */
+				do_action( 'darkmatter_primary_unset', $domain_before->domain, $domain_before->blog_id, true );
 			}
 
 			$domain_after = new DM_Domain( (object) $_domain );

--- a/domain-mapping/api/class-darkmatter-domains.php
+++ b/domain-mapping/api/class-darkmatter-domains.php
@@ -634,6 +634,66 @@ class DarkMatter_Domains {
 	}
 
 	/**
+	 * Helper to set the Primary Domain cache.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param string  $domain  Domain to set as primary.
+	 * @param integer $blog_id Blog ID for the site to have the new primary.
+	 * @return void
+	 */
+	private function primary_set( $domain = '', $blog_id = 0 ) {
+		$current_primary = DarkMatter_Primary::instance()->get( $blog_id );
+
+		if ( ! empty( $current_primary ) && $domain !== $current_primary->domain ) {
+			$this->update( $current_primary->domain, false, null, true, $current_primary->active );
+		}
+
+		/**
+		 * Update the primary domain cache.
+		 */
+		$primary_cache_key = $blog_id . '-primary';
+
+		/**
+		 * Fires when a domain is set to be the primary for a Site.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param  string  $domain  Domain that is set to primary domain.
+		 * @param  integer $site_id Site ID.
+		 * @param  boolean $db      States if the change performed a database update.
+		 */
+		do_action( 'darkmatter_primary_set', $domain, $blog_id, true );
+
+		wp_cache_set( $primary_cache_key, $domain, 'dark-matter' );
+	}
+
+	/**
+	 * Helper to set the Primary Domain cache.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param string  $domain  Domain to unset as primary.
+	 * @param integer $blog_id Blog ID for the site to remove the primary.
+	 * @return void
+	 */
+	private function primary_unset( $domain = '', $blog_id = 0 ) {
+		$primary_cache_key = $blog_id . '-primary';
+		wp_cache_delete( $primary_cache_key, 'dark-matter' );
+
+		/**
+		 * Fires when a domain is unset to be the primary for a Site.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param  string  $domain  Domain that is unset to primary domain.
+		 * @param  integer $site_id Site ID.
+		 * @param  boolean $db      States if the change performed a database update.
+		 */
+		do_action( 'darkmatter_primary_unset', $domain, $blog_id, true );
+	}
+
+	/**
 	 * Add a reserved domain for the Network in WordPress.
 	 *
 	 * @since 2.0.0

--- a/domain-mapping/api/class-darkmatter-primary.php
+++ b/domain-mapping/api/class-darkmatter-primary.php
@@ -153,39 +153,29 @@ class DarkMatter_Primary {
 	 *
 	 * @param  integer $site_id Site ID to set the primary domain cache for.
 	 * @param  string  $domain  Domain to be stored in the cache.
-	 * @param  boolean $db      Set to true to perform a database update.
-	 * @return void
+	 * @return boolean True on success, false otherwise.
 	 */
-	public function set( $site_id = 0, $domain = '', $db = false ) {
-		$site_id   = ( empty( $site_id ) ? get_current_blog_id() : $site_id );
-		$cache_key = $site_id . '-primary';
+	public function set( $site_id = 0, $domain = '' ) {
+		$new_primary_domain = DarkMatter_Domains::instance()->get( $domain );
 
-		if ( $db ) {
-			$result = $this->wpdb->update(
-				$this->dm_table,
-				array(
-					'is_primary' => true,
-				),
-				array(
-					'domain' => $domain,
-				)
-			);
+		if ( $new_primary_domain->blog_id !== $site_id ) {
+			return false;
 		}
 
-		/**
-		 * Fires when a domain is set to be the primary for a Site.
-		 *
-		 * @since 2.0.0
-		 *
-		 * @param  string  $domain  Domain that is set to primary domain.
-		 * @param  integer $site_id Site ID.
-		 * @param  boolean $db      States if the change performed a database update.
-		 */
-		do_action( 'darkmatter_primary_set', $domain, $site_id, $db );
+		$result = DarkMatter_Domains::instance()->update(
+			$new_primary_domain->domain,
+			true,
+			$new_primary_domain->is_https,
+			true,
+			$new_primary_domain->active,
+			DM_DOMAIN_TYPE_MAIN
+		);
 
-		wp_cache_set( $cache_key, $domain, 'dark-matter' );
+		if ( is_wp_error( $result ) ) {
+			return false;
+		}
 
-		$this->update_last_changed();
+		return true;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,9 @@ Google Analytics) with over 60 websites.
 
 = 2.3.0 =
 
+* Fixed an issue where setting and unsetting the Primary Domain would update the database only, and not the cache.
+  * `DarkMatter_Domains` now handles the cache state for both primary and general domain caches.
+  * Also removes some duplicate database update logic.
 * Fixed a typo preventing the cache retrieval for Restricted Domains working properly.
 * Fixed a malformed header for the 2.2.3 release in readme.txt file.
 * First iteration of unit tests added to the project to improve quality assurance of this release and future releases.

--- a/readme.txt
+++ b/readme.txt
@@ -84,6 +84,7 @@ Google Analytics) with over 60 websites.
 * Fixed an issue where setting and unsetting the Primary Domain would update the database only, and not the cache.
   * `DarkMatter_Domains` now handles the cache state for both primary and general domain caches.
   * Also removes some duplicate database update logic.
+  * The third parameter of action hooks `darkmatter_primary_set` and `darkmatter_primary_unset` is now deprecated. It is always `true` as the database is always updated now, therefore it is redundant.
 * Domains are now ordered alphabetically - A to Z - when returned by `get_domains_by_type()`.
 * Fixed a typo preventing the cache retrieval for Restricted Domains working properly.
 * Fixed a malformed header for the 2.2.3 release in readme.txt file.


### PR DESCRIPTION
This resolves the issue found in the new unit tests by rearranging the logic for primary domains to ensure both the database and cache stay in sync.

Namely, the cache handling is mostly moved to `DarkMatter_Domains` instead of `DarkMatter_Primary` by ensuring the "updates" for domains are managed in a single place. This also removes some duplicate database logic that was missed in previous iterations of the plugin since version 2.0.0.

Resolves the two unit test errors:
```
5) PrimaryDomainTest::test_set_primary_domain
Cached update to primary.
Failed asserting that false is true.

/home/runner/work/dark-matter/dark-matter/tests/phpunit/domain-mapping/PrimaryDomainTest.php:124

6) PrimaryDomainTest::test_unset_primary_domain
Cached update to unset primary.
Failed asserting that true is false.

/home/runner/work/dark-matter/dark-matter/tests/phpunit/domain-mapping/PrimaryDomainTest.php:160
```

Fixes: https://github.com/cameronterry/dark-matter/issues/93