### PR TITLE
Tweaked the get_domains_by_type() to return alphabetically

### DIFF
--- a/domain-mapping/api/class-darkmatter-domains.php
+++ b/domain-mapping/api/class-darkmatter-domains.php
@@ -496,7 +496,7 @@ class DarkMatter_Domains {
 							'is_https'   => true,
 							'is_primary' => false,
 							'type'       => DM_DOMAIN_TYPE_MEDIA,
-						] 
+						]
 					);
 				}
 
@@ -524,7 +524,7 @@ class DarkMatter_Domains {
 		if ( $skip_cache || ! is_array( $_domains ) ) {
 			$_domains = $wpdb->get_col(
 				$wpdb->prepare(
-					"SELECT domain FROM {$this->dm_table} WHERE blog_id = %d AND type = %d AND active = 1 ORDER BY domain DESC, domain", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"SELECT domain FROM {$this->dm_table} WHERE blog_id = %d AND type = %d AND active = 1 ORDER BY domain", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					$site_id,
 					$type
 				)

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ Google Analytics) with over 60 websites.
 
 = 2.3.0 =
 
+* Domains are now ordered alphabetically - A to Z - when returned by `get_domains_by_type()`.
 * Fixed a typo preventing the cache retrieval for Restricted Domains working properly.
 * Fixed a malformed header for the 2.2.3 release in readme.txt file.
 * First iteration of unit tests added to the project to improve quality assurance of this release and future releases.

--- a/tests/phpunit/domain-mapping/MediaDomainsTest.php
+++ b/tests/phpunit/domain-mapping/MediaDomainsTest.php
@@ -91,7 +91,7 @@ class MediaDomainsTest extends WP_UnitTestCase {
 			);
 		}
 
-		$this->assertEquals( $expected, $domains, 'Media domains set by constant.' );
+		$this->assertEquals( $expected, $domains, 'Media domains set manually.' );
 	}
 
 	/**


### PR DESCRIPTION
This method was causing an "error" in the unit tests as the array mismatched the return.

Not really an "bug" per se, but the ordering of results from `get_domains_by_type()` was weird and making it return alphabetically - A to Z - makes more sense.

Resolves the following unit test error:
```
4) MediaDomainsTest::test_get_media_domains_manual
Media domains set by constant.
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     0 => DM_Domain Object (
-        'id' => 18
+        'id' => 20
         'blog_id' => 17
         'is_primary' => false
-        'domain' => 'cdn1.mappeddomain1.test'
+        'domain' => 'cdn3.mappeddomain1.test'
         'active' => true
         'is_https' => true
         'type' => 2
@@ @@
     )
     1 => DM_Domain Object (...)
     2 => DM_Domain Object (
-        'id' => 20
+        'id' => 18
         'blog_id' => 17
         'is_primary' => false
-        'domain' => 'cdn3.mappeddomain1.test'
+        'domain' => 'cdn1.mappeddomain1.test'
         'active' => true
         'is_https' => true
         'type' => 2
     )
 )

/home/runner/work/dark-matter/dark-matter/tests/phpunit/domain-mapping/MediaDomainsTest.php:94
```