### PR TITLE
Retrieving REST URL in a switch_to_blog() context

### DIFF
--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -174,7 +174,33 @@ class DM_URL {
 	 * @return boolean True if the domain is the Primary domain. False if the Admin domain.
 	 */
 	private function is_mapped() {
-		return ( defined( 'DOMAIN_MAPPING' ) && DOMAIN_MAPPING );
+		/**
+		 * Here we determine if the request went through `sunrise.php` and was handled by Dark Matter plugin, which
+		 * translated the primary domain to a `WP_Site`.
+		 */
+		$mapped_request = ( defined( 'DOMAIN_MAPPING' ) && DOMAIN_MAPPING );
+
+		/**
+		 * Check to see if this was called within a `switch_to_blog()` context.
+		 *
+		 * If we are and the request was originally mapped to a primary domain, then we check to ensure the blog within
+		 * the context can be mapped (i.e. it has an active primary domain) and if so, we say the request is mapped.
+		 */
+		global $switched;
+		if ( $switched && $mapped_request ) {
+			$primary = DarkMatter_Primary::instance()->get();
+
+			/**
+			 * If there is no primary or if it is inactive, then the site is not mapped.
+			 */
+			if ( false === $primary || ! $primary->active ) {
+				return false;
+			}
+
+			return true;
+		}
+
+		return $mapped_request;
 	}
 
 	/**

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -15,11 +15,22 @@ defined( 'ABSPATH' ) || die();
  */
 class DM_URL {
 	/**
+	 * Determine if the current request was mapped in `sunrise.php`.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @var bool
+	 */
+	public $is_request_mapped = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 2.0.0
 	 */
 	public function __construct() {
+		$this->is_request_mapped = ( defined( 'DOMAIN_MAPPING' ) && DOMAIN_MAPPING );
+
 		/**
 		 * In some circumstances, we always want to process the logic regardless of request type, circumstances,
 		 * conditions, etc. (like ensuring saved post data is unmapped properly).
@@ -175,19 +186,13 @@ class DM_URL {
 	 */
 	private function is_mapped() {
 		/**
-		 * Here we determine if the request went through `sunrise.php` and was handled by Dark Matter plugin, which
-		 * translated the primary domain to a `WP_Site`.
-		 */
-		$mapped_request = ( defined( 'DOMAIN_MAPPING' ) && DOMAIN_MAPPING );
-
-		/**
 		 * Check to see if this was called within a `switch_to_blog()` context.
 		 *
 		 * If we are and the request was originally mapped to a primary domain, then we check to ensure the blog within
 		 * the context can be mapped (i.e. it has an active primary domain) and if so, we say the request is mapped.
 		 */
 		global $switched;
-		if ( $switched && $mapped_request ) {
+		if ( $switched && $this->is_request_mapped ) {
 			$primary = DarkMatter_Primary::instance()->get();
 
 			/**
@@ -200,7 +205,7 @@ class DM_URL {
 			return true;
 		}
 
-		return $mapped_request;
+		return $this->is_request_mapped;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,10 @@ Google Analytics) with over 60 websites.
 
 = 2.3.0 =
 
+* Tweaked the way mapped domains are detected to better support scenarios involving `switch_to_blog()`.
+  * No longer relies solely on the `DOMAIN_MAPPING` constant, set when a request is processed through a primary domain.
+  * Essentially, if the website handling the request is being viewed through its primary domain, then URLs within a `switch_to_blog()` context will be mapped if applicable (i.e. the blog switched to has an active primary domain).
+  * And vice-versa - if a request is through the admin domain ("unmapped"), then URLs in the `switch_to_blog()` context will be unmapped as well (to prevent cross-domain compatibility issues / warnings in browsers).
 * Fixed an issue where setting and unsetting the Primary Domain would update the database only, and not the cache.
   * `DarkMatter_Domains` now handles the cache state for both primary and general domain caches.
   * Also removes some duplicate database update logic.

--- a/tests/phpunit/domain-mapping/MappingDomainsTest.php
+++ b/tests/phpunit/domain-mapping/MappingDomainsTest.php
@@ -191,7 +191,7 @@ class MappingDomainsTest extends \WP_UnitTestCase {
 			 * Ensure the REST URL is HTTPS (it gets confused because it checks a number of `$_SERVER` variables).
 			 */
 			set_url_scheme( get_rest_url(), 'https' ),
-			sprintf( 'https://%1$s/siteone/wp-json/', $this->primary_domain ),
+			sprintf( 'https://%1$s/wp-json/', $this->primary_domain ),
 			'REST API URL'
 		);
 	}

--- a/tests/phpunit/domain-mapping/MappingDomainsTest.php
+++ b/tests/phpunit/domain-mapping/MappingDomainsTest.php
@@ -186,6 +186,8 @@ class MappingDomainsTest extends \WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_rest_url() {
+		DM_URL::instance()->is_request_mapped = true;
+
 		$this->assertEquals(
 			/**
 			 * Ensure the REST URL is HTTPS (it gets confused because it checks a number of `$_SERVER` variables).
@@ -194,5 +196,7 @@ class MappingDomainsTest extends \WP_UnitTestCase {
 			sprintf( 'https://%1$s/wp-json/', $this->primary_domain ),
 			'REST API URL'
 		);
+
+		DM_URL::instance()->is_request_mapped = false;
 	}
 }


### PR DESCRIPTION
Calling `get_rest_url()` in a `switch_to_blog()` context incorrectly returned the URL in certain circumstances, especially if the site had a mapped domain.

The detection of mapped domains and request is mapped (i.e. went through `sunrise.php`) has been tweaked to be more nuanced and better ensure the right URLs return in the right circumstances. Now, if the request is mapped and `switch_to_blog()` is used, then the URLs of the other website will be mapped if that site has an active primary domain.

If it does not, then the URLs are unmapped to ensure there is no cross domain request errors and warnings, especially important if `get_rest_url()` is called as it is likely being used for AJAX requests.

Also switched the way `DM_URL` detects the `DOMAIN_MAPPING` constant so that it can be controlled through a property as well as the constant, to improve the ability to test more effectively in unit tests. Also opens some new flexibility for developers to control the deeper logic of the URL mapping / unmapping process.

Last but not least, fixed the URL for the REST URL unit test as it incorrectly contained the site folder name (which is removed for a mapped domain).

Resolves unit test:
```
3) MappingDomainsTest::test_rest_url
REST API URL
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'https://darkmatter.test/siteone/wp-json/'
+'https://mappeddomain1.test/siteone/wp-json/'

/home/runner/work/dark-matter/dark-matter/tests/phpunit/domain-mapping/MappingDomainsTest.php:195
```

Fixes: https://github.com/cameronterry/dark-matter/issues/92