### PR TITLE
Media domain support for switch_to_blog()

### DIFF
--- a/domain-mapping/api/class-darkmatter-domains.php
+++ b/domain-mapping/api/class-darkmatter-domains.php
@@ -24,6 +24,13 @@ class DarkMatter_Domains {
 	private $dmtable = '';
 
 	/**
+	 * Hard-coded media domains, most likely through `DM_NETWORK_MEDIA` constant.
+	 *
+	 * @var array
+	 */
+	public $network_media = [];
+
+	/**
 	 * Reference to the global $wpdb and is more for code cleaniness.
 	 *
 	 * @since 2.0.0
@@ -51,6 +58,10 @@ class DarkMatter_Domains {
 		 * Store a reference to $wpdb as it will be used a lot.
 		 */
 		$this->wpdb = $wpdb;
+
+		if ( defined( 'DM_NETWORK_MEDIA' ) && ! empty( DM_NETWORK_MEDIA ) ) {
+			$this->network_media = DM_NETWORK_MEDIA;
+		}
 	}
 
 	/**
@@ -481,17 +492,17 @@ class DarkMatter_Domains {
 		/**
 		 * Media domains can be set with a constant.
 		 */
-		if ( DM_DOMAIN_TYPE_MEDIA === $type && defined( 'DM_NETWORK_MEDIA' ) ) {
+		if ( DM_DOMAIN_TYPE_MEDIA === $type && ! empty( $this->network_media ) ) {
 			/**
 			 * Ensure it is an array and then return. No checks, we assume that is provided correctly.
 			 */
-			if ( is_array( DM_NETWORK_MEDIA ) ) {
+			if ( is_array( $this->network_media ) ) {
 				$media_domains = [];
 
 				/**
 				 * Convert the domains into DM_Domain objects.
 				 */
-				foreach ( DM_NETWORK_MEDIA as $i => $media_domain ) {
+				foreach ( $this->network_media as $i => $media_domain ) {
 					$media_domains[ $i ] = new DM_Domain(
 						(object) [
 							'active'     => true,

--- a/domain-mapping/classes/class-dm-media.php
+++ b/domain-mapping/classes/class-dm-media.php
@@ -350,6 +350,11 @@ class DM_Media {
 			return;
 		}
 
+		/**
+		 * Seemingly WordPress' `wp_get_attachment_url()` doesn't seem to fully work as intended for `switch_to_blog()`.
+		 * Therefore we must add the requesters' main domains in order for the map / unmap to work, as the media assets
+		 * will be served on the requesters' domains rather than the domain of the site it belongs to.
+		 */
 		$main_domains = array_filter(
 			array_merge(
 				$main_domains,

--- a/domain-mapping/classes/class-dm-media.php
+++ b/domain-mapping/classes/class-dm-media.php
@@ -23,6 +23,13 @@ class DM_Media {
 	private $current_site_id = 0;
 
 	/**
+	 * Store the main domains for the request site (i.e. the one before any `switch_to_blog()` calls).
+	 *
+	 * @var array
+	 */
+	private $request_main_domains = [];
+
+	/**
 	 * Storage of the per site settings.
 	 *
 	 * @var array
@@ -342,6 +349,13 @@ class DM_Media {
 			$this->sites[ $site_id ] = false;
 			return;
 		}
+
+		$main_domains = array_filter(
+			array_merge(
+				$main_domains,
+				$this->request_main_domains
+			)
+		);
 
 		$this->sites[ $site_id ] = [
 			'allowed_mimes'       => $this->get_mime_types(),

--- a/domain-mapping/classes/class-dm-media.php
+++ b/domain-mapping/classes/class-dm-media.php
@@ -37,7 +37,7 @@ class DM_Media {
 	public function __construct() {
 		add_action( 'init', array( $this, 'init' ), 10 );
 		add_action( 'rest_api_init', array( $this, 'prepare_rest' ) );
-		add_action( 'switch_blog', array( $this, 'init' ), 10, 1 );
+		add_action( 'switch_blog', array( $this, 'switch_blog' ), 10, 1 );
 
 		add_filter( 'the_content', array( $this, 'map' ), 100, 1 );
 		add_filter( 'wp_get_attachment_url', array( $this, 'map_url' ), 100, 1 );
@@ -127,13 +127,14 @@ class DM_Media {
 	/**
 	 * Initialise the Media setup.
 	 *
-	 * @param int $site_id Site (Blog) ID, used to retrieve the site details and Primary Domain.
 	 * @return void
 	 *
 	 * @since 2.2.0
 	 */
-	public function init( $site_id = 0 ) {
-		$this->current_site_id = ( ! empty( $site_id ) ? intval( $site_id ) : get_current_blog_id() );
+	public function init() {
+		$this->current_site_id      = get_current_blog_id();
+		$this->request_main_domains = $this->get_main_domains( $this->current_site_id );
+
 		$this->prime_site( $this->current_site_id );
 	}
 
@@ -352,6 +353,19 @@ class DM_Media {
 			 */
 			'unmapped'            => $main_domains[0],
 		];
+	}
+
+	/**
+	 * Handle the `switch_to_blog()` / `restore_current_blog()` functionality.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param int $site_id Site (Blog) ID, used to retrieve the site details and Primary Domain.
+	 * @return void
+	 */
+	public function switch_blog( $site_id = 0 ) {
+		$this->current_site_id = ( ! empty( $site_id ) ? intval( $site_id ) : get_current_blog_id() );
+		$this->prime_site( $this->current_site_id );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,10 @@ Google Analytics) with over 60 websites.
 
 = 2.3.0 =
 
+* Added `switch_to_blog()` support for Media Domains.
+  * When using the various attachment functions within the `switch_to_blog()` context, it will now respect media domain settings on a per site basis.
+  * Setting media domains through the `DM_NETWORK_MEDIA` constant now works more fully.
+  * It is now possible to controlled media domains through the `network_media` property on DarkMatter_Domains, to enable more sophisticated logic in code.
 * Tweaked the way mapped domains are detected to better support scenarios involving `switch_to_blog()`.
   * No longer relies solely on the `DOMAIN_MAPPING` constant, set when a request is processed through a primary domain.
   * Essentially, if the website handling the request is being viewed through its primary domain, then URLs within a `switch_to_blog()` context will be mapped if applicable (i.e. the blog switched to has an active primary domain).

--- a/readme.txt
+++ b/readme.txt
@@ -84,7 +84,7 @@ Google Analytics) with over 60 websites.
 * Added `switch_to_blog()` support for Media Domains.
   * When using the various attachment functions within the `switch_to_blog()` context, it will now respect media domain settings on a per site basis.
   * Setting media domains through the `DM_NETWORK_MEDIA` constant now works more fully.
-  * It is now possible to controlled media domains through the `network_media` property on DarkMatter_Domains, to enable more sophisticated logic in code.
+  * It is now possible to controlled media domains through the `network_media` property on `DarkMatter_Domains`, to enable more sophisticated logic in code.
 * Tweaked the way mapped domains are detected to better support scenarios involving `switch_to_blog()`.
   * No longer relies solely on the `DOMAIN_MAPPING` constant, set when a request is processed through a primary domain.
   * Essentially, if the website handling the request is being viewed through its primary domain, then URLs within a `switch_to_blog()` context will be mapped if applicable (i.e. the blog switched to has an active primary domain).

--- a/tests/phpunit/domain-mapping/MappingDomainsTest.php
+++ b/tests/phpunit/domain-mapping/MappingDomainsTest.php
@@ -28,7 +28,7 @@ class MappingDomainsTest extends \WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	private static $media_domain = 'cdn.example.test';
+	private $media_domain = 'cdn.example.test';
 
 	/**
 	 * Post
@@ -69,10 +69,8 @@ class MappingDomainsTest extends \WP_UnitTestCase {
 		/**
 		 * Add domains to the new site.
 		 */
-		$result = DarkMatter_Domains::instance()->add(
+		DarkMatter_Domains::instance()->add(
 			$this->primary_domain,
-			true,
-			true,
 			true,
 			true
 		);
@@ -115,7 +113,7 @@ class MappingDomainsTest extends \WP_UnitTestCase {
 		$url = wp_get_attachment_image_url( $this->attachment );
 		$pos = stripos(
 			$url,
-			sprintf( 'https://%1$s/', self::$media_domain )
+			sprintf( 'https://%1$s/', $this->media_domain )
 		);
 
 		$this->assertNotFalse( $pos, '' );
@@ -142,7 +140,7 @@ class MappingDomainsTest extends \WP_UnitTestCase {
 		$html = get_the_post_thumbnail( $this->post->ID );
 		$pos  = stripos(
 			$html,
-			sprintf( 'https://%1$s/', self::$media_domain )
+			sprintf( 'https://%1$s/', $this->media_domain )
 		);
 
 		$this->assertNotFalse( $pos, '' );

--- a/tests/phpunit/domain-mapping/MappingDomainsTest.php
+++ b/tests/phpunit/domain-mapping/MappingDomainsTest.php
@@ -64,6 +64,10 @@ class MappingDomainsTest extends \WP_UnitTestCase {
 			]
 		);
 
+		DarkMatter_Domains::instance()->network_media = [
+			$this->media_domain,
+		];
+
 		switch_to_blog( $this->blog_id );
 
 		/**

--- a/tests/phpunit/domain-mapping/MediaDomainsTest.php
+++ b/tests/phpunit/domain-mapping/MediaDomainsTest.php
@@ -36,9 +36,7 @@ class MediaDomainsTest extends WP_UnitTestCase {
 			]
 		);
 	}
-
-
-
+	
 	/**
 	 * Media domains set by the `DM_NETWORK_MEDIA` constant.
 	 *

--- a/tests/phpunit/domain-mapping/MediaDomainsTest.php
+++ b/tests/phpunit/domain-mapping/MediaDomainsTest.php
@@ -40,11 +40,49 @@ class MediaDomainsTest extends WP_UnitTestCase {
 
 
 	/**
+	 * Media domains set by the `DM_NETWORK_MEDIA` constant.
+	 *
+	 * @return void
+	 */
+	public function test_get_media_domains_constant() {
+		$constant_domains = [
+			'cdn1.darkmatter.test',
+		];
+
+		DarkMatter_Domains::instance()->network_media = $constant_domains;
+
+		$domains = DarkMatter_Domains::instance()->get_domains_by_type();
+
+		$expected = [];
+
+		foreach ( $constant_domains as $media_domain ) {
+			$expected[] = new DM_Domain(
+				(object) [
+					'active'     => true,
+					'blog_id'    => get_current_blog_id(),
+					'domain'     => $media_domain,
+					'id'         => -1,
+					'is_https'   => true,
+					'is_primary' => false,
+					'type'       => DM_DOMAIN_TYPE_MEDIA,
+				]
+			);
+		}
+
+		$this->assertEquals( $expected, $domains, 'Media domains set by constant.' );
+	}
+
+	/**
 	 * Get media domains as set by an administrator.
 	 *
 	 * @return void
 	 */
 	public function test_get_media_domains_manual() {
+		/**
+		 * Reset any hard-coded media domains.
+		 */
+		DarkMatter_Domains::instance()->network_media = [];
+
 		$media_domains = [
 			'cdn1.mappeddomain1.test' => -1,
 			'cdn2.mappeddomain1.test' => -1,
@@ -92,43 +130,5 @@ class MediaDomainsTest extends WP_UnitTestCase {
 		}
 
 		$this->assertEquals( $expected, $domains, 'Media domains set manually.' );
-	}
-
-	/**
-	 * Media domains set by the `DM_NETWORK_MEDIA` constant.
-	 *
-	 * @return void
-	 */
-	public function test_get_media_domains_constant() {
-		/**
-		 * This is a bit of fudge, but by making this test last ... `DM_NETWORK_MEDIA` constant does not interfere with
-		 * the previous test for media domains manual.
-		 */
-		define(
-			'DM_NETWORK_MEDIA',
-			[
-				'cdn1.darkmatter.test',
-			]
-		);
-
-		$domains = DarkMatter_Domains::instance()->get_domains_by_type();
-
-		$expected = [];
-
-		foreach ( DM_NETWORK_MEDIA as $media_domain ) {
-			$expected[] = new DM_Domain(
-				(object) [
-					'active'     => true,
-					'blog_id'    => get_current_blog_id(),
-					'domain'     => $media_domain,
-					'id'         => -1,
-					'is_https'   => true,
-					'is_primary' => false,
-					'type'       => DM_DOMAIN_TYPE_MEDIA,
-				]
-			);
-		}
-
-		$this->assertEquals( $expected, $domains, 'Media domains set by constant.' );
 	}
 }


### PR DESCRIPTION
A rethink of the `DM_Media` to get it working with `switch_to_blog()`. Media domains functionality is now more aware of the context switches and now has the capability to retrieve settings on a per site basis and recall them when needed.

Also `DarkMatter_Domains` no longer has a hard requirement for the `DM_NETWORK_MEDIA` constant to be the only way to hard-code the media domains. Using `DarkMatter_Domains::instance()->network_media` property now affords the opportunity for more sophisticated logic to be applied - for example: someone could theoretically group sites together and serve them on a specific set of CDN domains for media assets. This is now easier to achieve that running the risk of accidentally defining the `DM_NETWORK_MEDIA` constant more than once.

This PR resolves the following unit test errors / warnings:
```
1) MappingDomainsTest::test_attachment_src
Failed asserting that false is not false.

/home/runner/work/dark-matter/dark-matter/tests/phpunit/domain-mapping/MappingDomainsTest.php:121

2) MappingDomainsTest::test_feature_image
Failed asserting that false is not false.

/home/runner/work/dark-matter/dark-matter/tests/phpunit/domain-mapping/MappingDomainsTest.php:148
```

Fixes: https://github.com/cameronterry/dark-matter/issues/91