### PR TITLE
Fix a malformed cache set

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "cameronterry/dark-matter",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "A highly opinionated domain mapping plugin for WordPress.",
     "type": "wordpress-plugin",
     "license": "GPL-2.0+",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bf9a1597a48057bf95978c1382de1f3",
+    "content-hash": "a673e4e8ac6aee3f8ba1a9d85dec36a6",
     "packages": [],
     "packages-dev": [
         {

--- a/dark-matter.php
+++ b/dark-matter.php
@@ -3,7 +3,7 @@
  * Plugin Name: Dark Matter
  * Plugin URI: https://github.com/cameronterry/dark-matter
  * Description: A highly opinionated domain mapping plugin for WordPress.
- * Version: 2.3.0
+ * Version: 2.3.1
  * Author: Cameron Terry
  * Author URI: https://github.com/cameronterry/
  * Text Domain: dark-matter
@@ -34,7 +34,7 @@ defined( 'ABSPATH' ) || die;
 
 /** Setup the Plugin Constants */
 define( 'DM_PATH', plugin_dir_path( __FILE__ ) );
-define( 'DM_VERSION', '2.3.0' );
+define( 'DM_VERSION', '2.3.1' );
 define( 'DM_DB_VERSION', '20210517' );
 
 define( 'DM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/domain-mapping/api/class-darkmatter-domains.php
+++ b/domain-mapping/api/class-darkmatter-domains.php
@@ -463,9 +463,9 @@ class DarkMatter_Domains {
 		 * When the domain is retrieved _and_ the domain is a "primary domain", then double-check that the primary
 		 * domain cache is set for it as well.
 		 */
-		$primary_cache_key = $_domain->blog_id . '-primary';
-		if ( $_domain->is_primary && empty( wp_cache_get( $primary_cache_key, 'dark-matter' ) ) ) {
-			wp_cache_set( $primary_cache_key, $_domain->domain, 'dark-matter' );
+		$primary_cache_key = $_domain['blog_id'] . '-primary';
+		if ( $_domain['is_primary'] && empty( wp_cache_get( $primary_cache_key, 'dark-matter' ) ) ) {
+			wp_cache_set( $primary_cache_key, $_domain['domain'], 'dark-matter' );
 		}
 
 		/**

--- a/domain-mapping/api/class-darkmatter-domains.php
+++ b/domain-mapping/api/class-darkmatter-domains.php
@@ -434,7 +434,7 @@ class DarkMatter_Domains {
 		 * Attempt to retrieve the domain from cache.
 		 */
 		$cache_key = md5( $fqdn );
-		$_domain   = wp_cache_get( $cache_key, 'dark-matter' );
+		$_domain   = (object) wp_cache_get( $cache_key, 'dark-matter' );
 
 		/**
 		 * If the domain cannot be retrieved from cache, attempt to retrieve it
@@ -463,9 +463,9 @@ class DarkMatter_Domains {
 		 * When the domain is retrieved _and_ the domain is a "primary domain", then double-check that the primary
 		 * domain cache is set for it as well.
 		 */
-		$primary_cache_key = $_domain['blog_id'] . '-primary';
-		if ( $_domain['is_primary'] && empty( wp_cache_get( $primary_cache_key, 'dark-matter' ) ) ) {
-			wp_cache_set( $primary_cache_key, $_domain['domain'], 'dark-matter' );
+		$primary_cache_key = $_domain->blog_id . '-primary';
+		if ( $_domain->is_primary && empty( wp_cache_get( $primary_cache_key, 'dark-matter' ) ) ) {
+			wp_cache_set( $primary_cache_key, $_domain->domain, 'dark-matter' );
 		}
 
 		/**

--- a/domain-mapping/api/class-darkmatter-domains.php
+++ b/domain-mapping/api/class-darkmatter-domains.php
@@ -457,7 +457,8 @@ class DarkMatter_Domains {
 			 * Update the primary cache if applicable.
 			 */
 			if ( $_domain->is_primary ) {
-				wp_cache_set( $_domain->blog_id . '-primary', 'dark-matter' );
+				$primary_cache_key = $_domain->blog_id . '-primary';
+				wp_cache_set( $primary_cache_key, $_domain->domain, 'dark-matter' );
 			}
 
 			/**

--- a/domain-mapping/api/class-darkmatter-domains.php
+++ b/domain-mapping/api/class-darkmatter-domains.php
@@ -454,19 +454,23 @@ class DarkMatter_Domains {
 			wp_cache_add( $cache_key, $_domain, 'dark-matter' );
 
 			/**
-			 * Update the primary cache if applicable.
-			 */
-			if ( $_domain->is_primary ) {
-				$primary_cache_key = $_domain->blog_id . '-primary';
-				wp_cache_set( $primary_cache_key, $_domain->domain, 'dark-matter' );
-			}
-
-			/**
 			 * We update the last changed here as the cache was modified.
 			 */
 			$this->update_last_changed();
 		}
 
+		/**
+		 * When the domain is retrieved _and_ the domain is a "primary domain", then double-check that the primary
+		 * domain cache is set for it as well.
+		 */
+		$primary_cache_key = $_domain->blog_id . '-primary';
+		if ( $_domain->is_primary && empty( wp_cache_get( $primary_cache_key, 'dark-matter' ) ) ) {
+			wp_cache_set( $primary_cache_key, $_domain->domain, 'dark-matter' );
+		}
+
+		/**
+		 * Return the DM_Domain object version.
+		 */
 		return new DM_Domain( (object) $_domain );
 	}
 

--- a/domain-mapping/api/class-darkmatter-primary.php
+++ b/domain-mapping/api/class-darkmatter-primary.php
@@ -95,8 +95,6 @@ class DarkMatter_Primary {
 
 				return false;
 			}
-
-			$this->set( $site_id, $primary_domain );
 		}
 
 		/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dark-matter",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dark-matter",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "GPL-2.0",
       "dependencies": {
         "@babel/runtime": "^7.17.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dark-matter",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Domain Mapping plugin for WordPress.",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: domain mapping, multisite
 Requires at least: 5.0
 Requires PHP: 7.0.0
 Tested up to: 5.9.3
-Stable tag: 2.3.0
+Stable tag: 2.3.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,6 +78,14 @@ Google Analytics) with over 60 websites.
 1. Admin interface for mapping Domains to a specific website.
 
 == Changelog ==
+
+= 2.3.1 =
+
+* Fixed a major performance issue introduced in 2.3.0 for excessive database calls for primary domains.
+  * This was caused by a malformed cache set for primary domains, after it was moved to resolve an issue previously where it would update only the database when a new primary domain was set.
+  * Also removed an old call to set a primary domain, which is no longer needed and was causing irrelevant `UPDATE` SQL queries (it was essentially update the values to exactly what they were already).
+* Moved the primary domain cache set when retrieving a domain to slightly later in the process.
+* Atypical installations should not need to flush the cache. However, you may need to use WP CLI `wp cache flush` - or equivalent - after upgrading.
 
 = 2.3.0 =
 


### PR DESCRIPTION
This PR resolves issue: https://github.com/cameronterry/dark-matter/issues/98

After changing the logic for Primary domains database calls and cache setting, moving that into `DarkMatter_Domains`, it appears that one small bug and a leftover call in `DarkMatter_Primary` is causing the excessive database calls.

* The small bug is a malformed call to `wp_cache_set()`, which forgot to include the value - the domain (`mappeddomain1.test`) - and was instead setting it to `dark-matter` which is the cache group.
* The `get()` method `DarkMatter_Primary` was still calling its own `set()` method, which was causing even cache miss to essentially issue an `UPDATE` SQL query. This has been removed as it is handled by `DarkMatter_Domains` now.