### PR TITLE
Fix: mapped URLs on login and register page

### DIFF
--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -66,7 +66,7 @@ class DM_URL {
 		 *
 		 * @link https://github.com/Yoast/wordpress-seo/blob/11.6/admin/links/class-link-content-processor.php#L43-L48 Yoast SEO code reference.
 		 */
-		if ( is_admin() && ! wp_doing_ajax() && ! empty( $_SERVER['REQUEST_METHOD'] ) && 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
+		if ( is_admin() && ! wp_doing_ajax() && ! empty( $_SERVER['REQUEST_METHOD'] ) && 'GET' !== wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) {
 			return;
 		}
 
@@ -149,7 +149,7 @@ class DM_URL {
 	 * @return string
 	 */
 	public function get_request_filename() {
-		$request_uri = ( empty( $_SERVER['REQUEST_URI'] ) ? '' : filter_var( $_SERVER['REQUEST_URI'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) );
+		$request_uri = ( empty( $_SERVER['REQUEST_URI'] ) ? '' : wp_unslash( wp_strip_all_tags( $_SERVER['REQUEST_URI'] ) ) );
 		$request     = ltrim( $request_uri, '/' );
 
 		/**

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -39,19 +39,20 @@ class DM_URL {
 		add_filter( 'wp_insert_post_data', array( $this, 'insert_post' ), -10, 1 );
 
 		/**
-		 * Domain Mapping's definition of "is admin" includes the login and register pages.
+		 * Ensure we do not map on the login and register pages.
 		 */
 		$admin_filenames = [
 			'wp-login.php'    => true,
 			'wp-register.php' => true,
 		];
 		$filename        = $this->get_request_filename();
-		if ( is_admin() || ( ! empty( $filename ) && array_key_exists( $filename, $admin_filenames ) ) ) {
+		if ( ! empty( $filename ) && array_key_exists( $filename, $admin_filenames ) ) {
 			/**
 			 * Ensure the "Go to [site name]" and Privacy Policy links still go to the mapped domain.
 			 */
 			add_filter( 'login_site_html_link', [ $this, 'map' ] ); // Supports WordPress 5.7+ only.
 			add_filter( 'privacy_policy_url', [ $this, 'map' ] ); // Supports WordPress 4.9.6+ only.
+
 			return;
 		}
 
@@ -65,7 +66,7 @@ class DM_URL {
 		 *
 		 * @link https://github.com/Yoast/wordpress-seo/blob/11.6/admin/links/class-link-content-processor.php#L43-L48 Yoast SEO code reference.
 		 */
-		if ( ! wp_doing_ajax() && ! empty( $_SERVER['REQUEST_METHOD'] ) && 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
+		if ( is_admin() && ! wp_doing_ajax() && ! empty( $_SERVER['REQUEST_METHOD'] ) && 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
 			return;
 		}
 

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -47,6 +47,11 @@ class DM_URL {
 		];
 		$filename        = $this->get_request_filename();
 		if ( is_admin() || ( ! empty( $filename ) && array_key_exists( $filename, $admin_filenames ) ) ) {
+			/**
+			 * Ensure the "Go to [site name]" and Privacy Policy links still go to the mapped domain.
+			 */
+			add_filter( 'login_site_html_link', [ $this, 'map' ] ); // Supports WordPress 5.7+ only.
+			add_filter( 'privacy_policy_url', [ $this, 'map' ] ); // Supports WordPress 4.9.6+ only.
 			return;
 		}
 

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -39,6 +39,18 @@ class DM_URL {
 		add_filter( 'wp_insert_post_data', array( $this, 'insert_post' ), -10, 1 );
 
 		/**
+		 * Domain Mapping's definition of "is admin" includes the login and register pages.
+		 */
+		$admin_filenames = [
+			'wp-login.php'    => true,
+			'wp-register.php' => true,
+		];
+		$filename        = $this->get_request_filename();
+		if ( is_admin() || ( ! empty( $filename ) && array_key_exists( $filename, $admin_filenames ) ) ) {
+			return;
+		}
+
+		/**
 		 * Prevent accidental URL mapping on requests which are not GET requests for the admin area. For example; a POST
 		 * request will include the postback for saving a post.
 		 *
@@ -48,7 +60,7 @@ class DM_URL {
 		 *
 		 * @link https://github.com/Yoast/wordpress-seo/blob/11.6/admin/links/class-link-content-processor.php#L43-L48 Yoast SEO code reference.
 		 */
-		if ( is_admin() && ! wp_doing_ajax() && ! empty( $_SERVER['REQUEST_METHOD'] ) && 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
+		if ( ! wp_doing_ajax() && ! empty( $_SERVER['REQUEST_METHOD'] ) && 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
 			return;
 		}
 

--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -126,6 +126,22 @@ class DM_URL {
 	}
 
 	/**
+	 * Get the filename, if it has one, from the current request.
+	 *
+	 * @return string
+	 */
+	public function get_request_filename() {
+		$request_uri = ( empty( $_SERVER['REQUEST_URI'] ) ? '' : filter_var( $_SERVER['REQUEST_URI'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) );
+		$request     = ltrim( $request_uri, '/' );
+
+		/**
+		 * Get the filename and remove any query strings.
+		 */
+		$filename = basename( $request );
+		return strtok( $filename, '?' );
+	}
+
+	/**
 	 * Checks to ensure that "mapped" domains are considered internal to WordPress and not external.
 	 *
 	 * @since 2.0.0


### PR DESCRIPTION
On the `wp-login.php` and `wp-register.php`, the CSS and JavaScript was being mapped to the primary domain (i.e example.test) rather than the admin domain (i.e. darkmatter.test). Technically does not affect anything, but as the page is loaded on the admin domain, it should load its assets on the same domain to prevent any issues (especially cross-domain related problems).

With a fresh set of eyes, I noticed there are at least two links which should be going to the mapped URL: the "Go to [Site Name]" link and the Privacy Policy.

This was noticed and repaired in the upcoming 3.0.0, https://github.com/cameronterry/dark-matter/pull/103/commits/45c9b662e44342ad0e5c447df4a9a7e999aafa13, and this PR brings this fix into 2.x.x development due to the unknown release date for 3.0.0.