### PR TITLE
PHP 8.1 Compatibility

### DIFF
--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -291,7 +291,7 @@ class DM_URL {
 		 * affect database and cache updates to ensure compatibility if the
 		 * domain mapping is changed or removed.
 		 */
-		$request_uri = ( empty( $_SERVER['REQUEST_URI'] ) ? '' : filter_var( $_SERVER['REQUEST_URI'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) );
+		$request_uri = ( empty( $_SERVER['REQUEST_URI'] ) ? '' : wp_strip_all_tags( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
 
 		/**
 		 * This is called for all requests as it is possible for the REST API to be called and process without a cURL

--- a/domain-mapping/inc/redirect.php
+++ b/domain-mapping/inc/redirect.php
@@ -79,7 +79,7 @@ function darkmatter_maybe_redirect() {
 		return;
 	}
 
-	$request_uri = ( empty( $_SERVER['REQUEST_URI'] ) ? '' : filter_var( $_SERVER['REQUEST_URI'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) );
+	$request_uri = ( empty( $_SERVER['REQUEST_URI'] ) ? '' : wp_strip_all_tags( wp_unslash( $_SERVER['REQUEST_URI'] ) ) );
 
 	$request = ltrim( $request_uri, '/' );
 
@@ -104,7 +104,7 @@ function darkmatter_maybe_redirect() {
 
 	$original_blog = get_site();
 
-	$http_host = ( empty( $_SERVER['HTTP_HOST'] ) ? '' : filter_var( $_SERVER['HTTP_HOST'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) );
+	$http_host = ( empty( $_SERVER['HTTP_HOST'] ) ? '' : wp_strip_all_tags( wp_unslash( $_SERVER['HTTP_HOST'] ) ) );
 
 	$host    = trim( $http_host, '/' );
 	$primary = DarkMatter_Primary::instance()->get();

--- a/domain-mapping/sso/class-dm-sso-cookie.php
+++ b/domain-mapping/sso/class-dm-sso-cookie.php
@@ -112,7 +112,7 @@ class DM_SSO_Cookie {
 	private function is_admin_domain() {
 		$network = get_network();
 
-		$http_host = ( empty( $_SERVER['HTTP_HOST'] ) ? '' : filter_var( $_SERVER['HTTP_HOST'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) );
+		$http_host = ( empty( $_SERVER['HTTP_HOST'] ) ? '' : wp_strip_all_tags( wp_unslash( $_SERVER['HTTP_HOST'] ) ) );
 
 		if ( ! empty( $network ) && false === stripos( $network->domain, $http_host ) ) {
 			return false;
@@ -141,13 +141,12 @@ class DM_SSO_Cookie {
 		echo '// dm_sso' . PHP_EOL;
 
 		if ( is_user_logged_in() ) {
-			$referer = ( empty( $_SERVER['HTTP_REFERER'] ) ? '' : filter_var( $_SERVER['HTTP_REFERER'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) );
+			$referer = ( empty( $_SERVER['HTTP_REFERER'] ) ? '' : wp_strip_all_tags( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) );
 
 			$action = sprintf(
 				'darkmatter-sso|%1$s|%2$s',
 				$referer,
-				md5( empty( $_SERVER['HTTP_USER_AGENT'] ) ? '' : filter_var( $_SERVER['HTTP_USER_AGENT'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) ),
-				get_current_user_id()
+				md5( empty( $_SERVER['HTTP_USER_AGENT'] ) ? '' : wp_strip_all_tags( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) )
 			);
 
 			/**
@@ -189,7 +188,7 @@ class DM_SSO_Cookie {
 		echo '// dm_sso' . PHP_EOL;
 
 		if ( false === is_user_logged_in() ) {
-			$referer = ( empty( $_SERVER['HTTP_REFERER'] ) ? '' : filter_var( $_SERVER['HTTP_REFERER'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) );
+			$referer = ( empty( $_SERVER['HTTP_REFERER'] ) ? '' : wp_strip_all_tags( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) );
 
 			$url = add_query_arg(
 				array(
@@ -296,7 +295,7 @@ class DM_SSO_Cookie {
 	 * @return void
 	 */
 	public function validate_token() {
-		$dm_action = filter_input( INPUT_GET, '__dm_action', FILTER_SANITIZE_STRING );
+		$dm_action = ( empty( $_GET['__dm_action'] ) ? '' : wp_strip_all_tags( wp_unslash( $_GET['__dm_action'] ) ) );
 
 		/**
 		 * Ensure that URLs with the __dm_action query string are not cached by browsers.
@@ -320,14 +319,13 @@ class DM_SSO_Cookie {
 			/**
 			 * Validate the token provided in the URL.
 			 */
-			$user_id = wp_validate_auth_cookie( filter_input( INPUT_GET, 'auth', FILTER_SANITIZE_STRING ), 'auth' );
-			$nonce   = filter_input( INPUT_GET, 'nonce', FILTER_SANITIZE_STRING );
+			$user_id = wp_validate_auth_cookie( wp_strip_all_tags( wp_unslash( $_GET['auth'] ) ), 'auth' );
+			$nonce   = wp_strip_all_tags( wp_unslash( $_GET['nonce'] ) );
 
 			$action = sprintf(
 				'darkmatter-sso|%1$s|%2$s',
-				( empty( $_SERVER['HTTP_REFERER'] ) ? '' : filter_var( $_SERVER['HTTP_REFERER'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) ),
-				md5( empty( $_SERVER['HTTP_USER_AGENT'] ) ? '' : filter_var( $_SERVER['HTTP_USER_AGENT'], FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW ) ),
-				$user_id
+				( empty( $_SERVER['HTTP_REFERER'] ) ? '' : wp_strip_all_tags( wp_unslash( $_SERVER['HTTP_REFERER'] ) ) ),
+				md5( empty( $_SERVER['HTTP_USER_AGENT'] ) ? '' : wp_strip_all_tags( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) )
 			);
 
 			/**

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,12 +2,16 @@
 <ruleset name="WordPress Coding Standards for Plugins">
     <description>Generally-applicable sniffs for WordPress plugins</description>
 
+    <config name="testVersion" value="8.0-" />
+
     <rule ref="WordPress-Extra" />
     <rule ref="WordPress-Docs" />
     <rule ref="WordPress-VIP-Go" />
 
     <rule ref="WordPress">
         <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+        <exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery" />
+        <exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching" />
         <exclude name="WordPress.Files.FileName" />
     </rule>
 


### PR DESCRIPTION
Small tweaks to ensure Dark Matter is compatible with [PHP 8.1](https://www.php.net/releases/8.1/en.php). This is prevent errors and warnings in PHP and ensure the functionality still works.

WordPress Core by and large supports PHP 8.0 and 8.1, https://make.wordpress.org/core/2022/01/10/wordpress-5-9-and-php-8-0-8-1/, so this brings Dark Matter in line with Core.

These changes mean that Dark Matter is compatible with PHP versions 7.0-8.1.