### PR TITLE
Fix REST API consistency for create domain

### DIFF
--- a/domain-mapping/rest/class-dm-rest-domains-controller.php
+++ b/domain-mapping/rest/class-dm-rest-domains-controller.php
@@ -49,7 +49,9 @@ class DM_REST_Domains_Controller extends WP_REST_Controller {
 		/**
 		 * Prepare response for successfully adding a domain.
 		 */
-		$response = rest_ensure_response( $result );
+		$response = rest_ensure_response(
+			$this->prepare_item_for_response( $result, $request )
+		);
 
 		$response->set_status( 201 );
 		$response->header( 'Location', rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->rest_base, $result->domain ) ) );


### PR DESCRIPTION
This PR includes:

* Fixed the response for creating a new domain on the REST API endpoint.
* It now returns the same structure as `get_item()` and `update()`, specifically it includes the sub-object structure for the WP_Site/blog, which was missing previously.
* Spotted in the 3.0.0 development.