### PR TITLE
Fixed domain mapping for Script Modules

### DIFF
--- a/domain-mapping/classes/class-dm-url.php
+++ b/domain-mapping/classes/class-dm-url.php
@@ -361,6 +361,7 @@ class DM_URL {
 
 		add_filter( 'script_loader_tag', array( $this, 'map' ), -10, 4 );
 		add_filter( 'style_loader_tag', array( $this, 'map' ), -10, 4 );
+		add_filter( 'script_module_loader_src', [ $this, 'map' ], -10, 4 );
 
 		add_filter( 'upload_dir', array( $this, 'upload' ), 10, 1 );
 	}


### PR DESCRIPTION
This PR includes:

* Fixed the mapping for Script Modules when loading on the primary domain.
* This uses it's own filter, `script_module_loader_src`, rather than `script_loader_tag`. Fixed tested with:
  * WooCommerce with Blocks and the new Product Editor enabled.
  * Human Made's Query Filter plugin.
* Introduced in WordPress 6.5: https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/.