### PR TITLE
Fix: Update admin menu on Domains admin screen when primary is changed

### DIFF
--- a/domain-mapping/classes/class-dm-ui.php
+++ b/domain-mapping/classes/class-dm-ui.php
@@ -111,7 +111,7 @@ class DM_UI {
 			wp_die( esc_html__( 'You do not have permission to manage domains.', 'dark-matter' ) );
 		}
 		?>
-		<div id="root"></div>
+		<div id="root" data-admin-domain="<?php echo esc_url( get_home_url( null, '/', 'unmapped' ) ); ?>"></div>
 		<?php
 	}
 }

--- a/domain-mapping/ui/API/Domains.js
+++ b/domain-mapping/ui/API/Domains.js
@@ -11,11 +11,15 @@ class Domains {
 	 * @param {Object} data Data record for the new domain.
 	 */
 	async add( data ) {
-		return await apiFetch( {
-			data,
-			method: 'POST',
-			path: '/dm/v1/domain',
-		} );
+		try {
+			return await apiFetch( {
+				data,
+				method: 'POST',
+				path: '/dm/v1/domain',
+			} );
+		} catch ( error ) {
+			return error;
+		}
 	}
 
 	/**

--- a/domain-mapping/ui/Components/DomainAdd.js
+++ b/domain-mapping/ui/Components/DomainAdd.js
@@ -39,11 +39,18 @@ class DomainAdd extends Component {
 		let message = '';
 
 		if ( result.code ) {
-			message = sprintf(
-				/* translators: error message */
-				__( 'Cannot add domain. %s', 'dark-matter' ),
-				result.message
-			);
+			if ( 'primary' === result.code ) {
+				message = sprintf(
+					__( 'Cannot add domain. Primary domain cannot be overridden by a new domain.', 'dark-matter' ),
+					result.message
+				);
+			} else {
+				message = sprintf(
+					/* translators: error message */
+					__( 'Cannot add domain. %s', 'dark-matter' ),
+					result.message
+				);
+			}
 		} else {
 			message = sprintf(
 				/* translators: added domain */

--- a/domain-mapping/ui/Components/DomainMapping.js
+++ b/domain-mapping/ui/Components/DomainMapping.js
@@ -112,6 +112,24 @@ class DomainMapping extends Component {
 	async getData() {
 		const result = await this.api.getAll();
 
+		const primary = result.find( ( domainRecord ) => domainRecord.is_primary );
+
+		const adminDomain = document.getElementById( 'root' ).dataset?.adminDomain ?? '';
+		const currentDomain = document.querySelector( '#wp-admin-bar-view-site > a' ).getAttribute( 'href' ).split( 'wp-admin' )[0];
+
+		if ( adminDomain && currentDomain ) {
+			document.querySelectorAll( `a[href*="${currentDomain}"][role="menuitem"]` ).forEach( ( menuItem ) => {
+				if ( primary && primary?.is_active ) {
+					menuItem.setAttribute( 'href',
+						( primary.is_https ? 'https' : 'http' )
+						+ `://${primary.domain}/`
+					);
+				} else {
+					menuItem.setAttribute( 'href', adminDomain );
+				}
+			} );
+		}
+
 		this.setState( {
 			domains: result,
 		} );


### PR DESCRIPTION
This PR includes:

* Admin menu now updates when the primary domain is changed.
* These updates are applied when the data is loaded, rather than specific actions. This captures changing the primary domain, adding as well as deleting.
* Resolves: https://github.com/cameronterry/dark-matter/issues/111